### PR TITLE
Phase 2 widgets: score breakdown tooltips + grade overview

### DIFF
--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -58,6 +58,26 @@
             </tbody>
         </table>
 
+        @{
+            var subjectAverages = GetSubjectAverages();
+        }
+
+        @if (subjectAverages.Any())
+        {
+            <div class="grade-overview">
+                <h2 class="grade-overview-title">Grade Overview</h2>
+                <div class="grade-overview-cards">
+                    @foreach (var (subject, avg) in subjectAverages.OrderBy(x => x.Value))
+                    {
+                        <div class="grade-overview-card">
+                            <span class="grade-overview-subject">@subject</span>
+                            <span class="grade-overview-value @GetGradeClass(avg)">@avg.ToString("F1")</span>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+
         <button class="button-primary" @onclick="OpenAddTestModal">Add test</button>
 
         @if (PastUngradedTests.Any())

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -39,6 +39,25 @@ public partial class Home(TestManagement management, AuthenticationStateProvider
         showPastCompleted = !showPastCompleted;
     }
 
+    // Average grade per subject across every graded test (only past tests can be graded).
+    private Dictionary<Test.Subjects, double> GetSubjectAverages()
+    {
+        return tests
+            .Where(t => t.Grade.HasValue)
+            .GroupBy(t => t.Subject)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Average(t => t.Grade!.Value)
+            );
+    }
+
+    private string GetGradeClass(double avg) => avg switch
+    {
+        >= 5 => "grade-good",
+        >= 4 => "grade-ok",
+        _ => "grade-poor"
+    };
+
     public enum Modes
     {
         AddTest,

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -38,7 +38,7 @@
                     {
                         var score = calculator.CalculateTotalScore(test, allTests);
                         var days = test.DueDate.DayNumber - DateOnly.FromDateTime(DateTime.Today).DayNumber;
-                        <div class="study-card">
+                        <div class="study-card" title="@GetScoreBreakdown(test)">
                             <div class="study-card-header">
                                 <h3 class="study-card-title">@test.Title</h3>
                                 <span class="study-card-score">@score / 40 pts</span>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -25,6 +25,16 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
         calculated = true;
     }
 
+    private string GetScoreBreakdown(Test test)
+    {
+        var urgency = calculator.CalculateUrgencyScore(test.DueDate);
+        var volume = calculator.CalculateVolumeScore(test.Volume);
+        var understanding = calculator.CalculateUnderstandingScore(test.Understanding);
+        var grade = calculator.CalculateGradeScore(test.Subject, allTests);
+
+        return $"Urgency: {urgency}/10 · Volume: {volume}/12 · Understanding: {understanding}/12 · Grade: {grade}/6";
+    }
+
     private string GetBecauseText(Test test)
     {
         var days = test.DueDate.DayNumber - DateOnly.FromDateTime(DateTime.Today).DayNumber;

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -52,7 +52,7 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
         };
 
         if (avgGrade > 0)
-            parts.Add($"your avg grade in {test.Subject} is {avgGrade:F1}");
+            parts.Add($"your average grade in {test.Subject} is {avgGrade:F1}");
 
         return string.Join(", ", parts);
     }

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -352,3 +352,55 @@ h1:focus {
     border-radius: 10px;
     padding: 12px 14px;
 }
+
+.grade-overview {
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
+}
+
+.grade-overview-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 12px;
+}
+
+.grade-overview-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.grade-overview-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 14px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-width: 110px;
+}
+
+.grade-overview-subject {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.grade-overview-value {
+    font-size: 24px;
+    font-weight: 700;
+}
+
+.grade-good {
+    color: #4caf50;
+}
+
+.grade-ok {
+    color: var(--accent);
+}
+
+.grade-poor {
+    color: #e57373;
+}


### PR DESCRIPTION
## Summary

Two widgets from `wsist-tasks-2.md` (one commit each):

1. **feat: add score breakdown tooltips to study cards** — each `.study-card` on `/study` now has a native `title` tooltip showing how the total score breaks down: `Urgency: x/10 · Volume: x/12 · Understanding: x/12 · Grade: x/6`. Added `GetScoreBreakdown(Test)` to `Study.razor.cs`.

2. **feat: add grade overview widget to home page** — a "Grade Overview" section below the upcoming-tests table shows the average grade per subject (from all graded tests), colour-coded good/ok/poor. Hidden when there are no graded tests.

## Adaptation note

Task 2 Step 1 ("Fix the test loading" — introduce an `allTests` field and re-filter `tests` to upcoming) was written against the pre-toggle code. Since PR #18 (merged) already changed `Home.razor.cs` so `tests` holds **all** tests with `UpcomingTests`/`PastUngradedTests`/`PastCompletedTests` as computed views, that step was unnecessary. `GetSubjectAverages()` computes directly from `tests`, which matches the task's intent without reintroducing a redundant date filter. The widget markup and CSS are as specified.

## Testing

`dotnet build` — no compile errors. (The only local build failures are a file lock on the running app's exe, not code issues.) Existing unit tests unaffected.

No migrations needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
