### PR TITLE
feat: phase 4 - reminders, post-study feedback, grade trends, weekly planner

### DIFF
--- a/WSIST/WSIST.Engine/PriorityCalculator.cs
+++ b/WSIST/WSIST.Engine/PriorityCalculator.cs
@@ -90,4 +90,26 @@ public class PriorityCalculator
             .Take(topCount)
             .ToList();
     }
+
+    // Plan the coming 7 days. A test repeating on several days is intentional —
+    // it has consistently high priority throughout the week and deserves repeated attention.
+    public Dictionary<DateOnly, List<Test>> GetWeeklyPlan(
+        List<Test> allTests,
+        Dictionary<DayOfWeek, double> hoursPerDay)
+    {
+        var plan = new Dictionary<DateOnly, List<Test>>();
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        for (int i = 0; i < 7; i++)
+        {
+            var date = today.AddDays(i);
+            var hours = hoursPerDay.GetValueOrDefault(date.DayOfWeek, 0);
+
+            plan[date] = hours > 0
+                ? GetStudyRecommendations(allTests, hours)
+                : [];
+        }
+
+        return plan;
+    }
 }

--- a/WSIST/WSIST.Engine/PriorityCalculator.cs
+++ b/WSIST/WSIST.Engine/PriorityCalculator.cs
@@ -2,9 +2,10 @@
 
 public class PriorityCalculator
 {
-    public int CalculateUrgencyScore(DateOnly dueDate)
+    public int CalculateUrgencyScore(DateOnly dueDate, DateOnly? asOfDate = null)
     {
-        var daysUntil = dueDate.DayNumber - DateOnly.FromDateTime(DateTime.Today).DayNumber;
+        var reference = asOfDate ?? DateOnly.FromDateTime(DateTime.Today);
+        var daysUntil = dueDate.DayNumber - reference.DayNumber;
 
         return daysUntil switch
         {
@@ -62,18 +63,19 @@ public class PriorityCalculator
         };
     }
 
-    public int CalculateTotalScore(Test test, List<Test> allTests)
+    public int CalculateTotalScore(Test test, List<Test> allTests, DateOnly? asOfDate = null)
     {
         var sum = 0;
-        sum += CalculateUrgencyScore(test.DueDate);
+        sum += CalculateUrgencyScore(test.DueDate, asOfDate);
         sum += CalculateVolumeScore(test.Volume);
         sum += CalculateUnderstandingScore(test.Understanding);
         sum += CalculateGradeScore(test.Subject, allTests);
         return sum;
     }
 
-    public List<Test> GetStudyRecommendations(List<Test> allTests, double hoursAvailable)
+    public List<Test> GetStudyRecommendations(List<Test> allTests, double hoursAvailable, DateOnly? asOfDate = null)
     {
+        var reference = asOfDate ?? DateOnly.FromDateTime(DateTime.Today);
         var topCount = hoursAvailable switch
         {
             < 1 => 1,
@@ -84,8 +86,8 @@ public class PriorityCalculator
         };
 
         return allTests
-            .Where(t => t.DueDate >= DateOnly.FromDateTime(DateTime.Today)) // exclude past tests
-            .OrderByDescending(t => CalculateTotalScore(t, allTests))
+            .Where(t => t.DueDate >= reference) // exclude tests already due by the reference date
+            .OrderByDescending(t => CalculateTotalScore(t, allTests, reference))
             .ThenBy(t => t.DueDate)
             .Take(topCount)
             .ToList();
@@ -106,7 +108,7 @@ public class PriorityCalculator
             var hours = hoursPerDay.GetValueOrDefault(date.DayOfWeek, 0);
 
             plan[date] = hours > 0
-                ? GetStudyRecommendations(allTests, hours)
+                ? GetStudyRecommendations(allTests, hours, date)
                 : [];
         }
 

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -131,6 +131,74 @@
             </div>
         }
 
+        @{
+            var gradeHistory = GetGradeHistory();
+        }
+
+        @if (gradeHistory.Any())
+        {
+            <div class="grade-trends">
+                <h2 class="grade-overview-title">Grade trends</h2>
+                <div class="grade-trend-grid">
+                    @foreach (var (subjectId, history) in gradeHistory)
+                    {
+                        var subjectName = subjects.FirstOrDefault(s => s.Id == subjectId)?.Name ?? subjectId.ToString();
+                        var latest = history.Last().Grade;
+                        var first = history.First().Grade;
+                        var trend = latest - first;
+
+                        // SVG dimensions
+                        const int w = 160;
+                        const int h = 56;
+                        const int pad = 8;
+                        int pts = history.Count;
+
+                        // Map grades (1–6) to Y coords — higher grade = lower Y value (top of SVG)
+                        string ToY(double g) => ((h - pad) - ((g - 1) / 5.0 * (h - pad * 2))).ToString("F1");
+                        string ToX(int i) => (pad + i * (double)(w - pad * 2) / (pts - 1)).ToString("F1");
+
+                        var points = string.Join(" ", history.Select((item, i) => $"{ToX(i)},{ToY(item.Grade)}"));
+                        var dotPoints = history.Select((item, i) => (X: ToX(i), Y: ToY(item.Grade), Grade: item.Grade)).ToList();
+
+                        <div class="grade-trend-card">
+                            <div class="grade-trend-header">
+                                <span class="grade-trend-subject">@subjectName</span>
+                                <span class="grade-trend-latest @GetGradeClass(latest)">@latest.ToString("F1")</span>
+                            </div>
+                            <svg viewBox="0 0 @w @h" class="grade-trend-svg" preserveAspectRatio="none">
+                                <!-- Guide lines at grades 4 and 5 -->
+                                <line x1="@pad" y1="@ToY(4)" x2="@(w - pad)" y2="@ToY(4)"
+                                      stroke="var(--border)" stroke-width="1" stroke-dasharray="3,3"/>
+                                <line x1="@pad" y1="@ToY(5)" x2="@(w - pad)" y2="@ToY(5)"
+                                      stroke="var(--border)" stroke-width="1" stroke-dasharray="3,3"/>
+                                <!-- Grade line -->
+                                <polyline points="@points"
+                                          fill="none"
+                                          stroke="var(--accent)"
+                                          stroke-width="1.5"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"/>
+                                <!-- Grade dots -->
+                                @foreach (var dot in dotPoints)
+                                {
+                                    <circle cx="@dot.X" cy="@dot.Y" r="3"
+                                            fill="var(--accent)" stroke="var(--bg-elevated)" stroke-width="1.5">
+                                        <title>@dot.Grade.ToString("F1")</title>
+                                    </circle>
+                                }
+                            </svg>
+                            <div class="grade-trend-footer">
+                                <span class="grade-trend-count">@history.Count test@(history.Count == 1 ? "" : "s")</span>
+                                <span class="grade-trend-delta @(trend >= 0 ? "delta-up" : "delta-down")">
+                                    @(trend >= 0 ? "↑" : "↓") @Math.Abs(trend).ToString("F1")
+                                </span>
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+
         @if (showModal && temporaryTest is not null)
         {
             <div class="wsist-modal">

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -31,6 +31,22 @@
             </div>
         </div>
 
+        @if (MissingGrades.Any())
+        {
+            <div class="missing-grades-strip">
+                <span class="missing-grades-label">⏳ Enter missing grades</span>
+                <div class="missing-grades-list">
+                    @foreach (var test in MissingGrades)
+                    {
+                        <button class="missing-grade-chip" @onclick="() => OpenEditTestModal(test)">
+                            @test.Title
+                            <span class="missing-grade-chip-date">@test.DueDate.ToShortDateString()</span>
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+
         @if (topRecommendation is not null)
         {
             var score = calculator.CalculateTotalScore(topRecommendation, allTests);

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -53,6 +53,21 @@ public partial class Home(
             );
     }
 
+    // Chronological grade history per subject, only for subjects with 2+ graded tests.
+    private Dictionary<int, List<(DateOnly Date, double Grade)>> GetGradeHistory()
+    {
+        return allTests
+            .Where(t => t.Grade.HasValue)
+            .GroupBy(t => t.Subject)
+            .Where(g => g.Count() >= 2)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(t => t.DueDate)
+                      .Select(t => (t.DueDate, t.Grade!.Value))
+                      .ToList()
+            );
+    }
+
     private string GetGradeClass(double avg) => avg switch
     {
         >= 5 => "grade-good",

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -21,6 +21,13 @@ public partial class Home(
 
     private static DateOnly Today => DateOnly.FromDateTime(DateTime.Today);
 
+    // Past tests that still have no grade entered, oldest first.
+    private List<Test> MissingGrades =>
+        allTests
+            .Where(t => t.DueDate < DateOnly.FromDateTime(DateTime.Today) && t.Grade == null)
+            .OrderBy(t => t.DueDate)
+            .ToList();
+
     protected override Task OnAuthenticatedAsync()
     {
         Refresh();

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -20,6 +20,17 @@
             <p>Tell us how much time you have — we'll figure out the rest.</p>
         </div>
 
+        <div class="study-mode-toggle">
+            <button class="study-mode-btn @(!weeklyMode ? "active" : "")" @onclick="() => weeklyMode = false">
+                Today
+            </button>
+            <button class="study-mode-btn @(weeklyMode ? "active" : "")" @onclick="() => weeklyMode = true">
+                This week
+            </button>
+        </div>
+
+        @if (!weeklyMode)
+        {
         <div class="study-input-card">
             <label class="study-input-label">Hours available today</label>
             <div class="study-input-row">
@@ -83,6 +94,65 @@
                                     <button class="button-primary studied-btn" @onclick="() => OpenStudiedPrompt(test)">
                                         ✓ Studied it
                                     </button>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        }
+        }
+        else
+        {
+            <div class="study-input-card">
+                <label class="study-input-label">Hours available each day</label>
+                <div class="weekly-hours-grid">
+                    @foreach (var day in weeklyHours.Keys)
+                    {
+                        <div class="weekly-hours-row">
+                            <span class="weekly-day-label">@day.ToString()[..3]</span>
+                            <input type="number" min="0" max="12" step="0.5"
+                                   value="@weeklyHours[day]"
+                                   @onchange="e => weeklyHours[day] = double.TryParse(e.Value?.ToString(), out var v) ? v : 0"/>
+                        </div>
+                    }
+                </div>
+                <button class="button-primary button-accent" style="align-self: flex-start; margin-top: 8px;" @onclick="CalculateWeekly">
+                    Plan my week
+                </button>
+            </div>
+
+            @if (weeklyCalculated)
+            {
+                <div class="weekly-plan">
+                    @foreach (var (date, tests) in weeklyPlan.OrderBy(x => x.Key))
+                    {
+                        <div class="weekly-day-block">
+                            <div class="weekly-day-header">
+                                <span class="weekly-day-name">@DayLabel(date)</span>
+                                @if (!tests.Any())
+                                {
+                                    <span class="weekly-day-off">Day off</span>
+                                }
+                            </div>
+                            @if (tests.Any())
+                            {
+                                <div class="weekly-day-tests">
+                                    @foreach (var test in tests)
+                                    {
+                                        var score = calculator.CalculateTotalScore(test, allTests);
+                                        var days = test.DueDate.DayNumber - date.DayNumber;
+                                        <div class="weekly-test-row">
+                                            <div class="weekly-test-info">
+                                                <span class="weekly-test-title">@test.Title</span>
+                                                <span class="weekly-test-meta">
+                                                    @(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? "Unknown")
+                                                    · @days day@(days == 1 ? "" : "s") away
+                                                </span>
+                                            </div>
+                                            <span class="weekly-test-score @GetGradeClass(score / 40.0 * 6)">@score/40</span>
+                                        </div>
+                                    }
                                 </div>
                             }
                         </div>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -140,7 +140,7 @@
                                 <div class="weekly-day-tests">
                                     @foreach (var test in tests)
                                     {
-                                        var score = calculator.CalculateTotalScore(test, allTests);
+                                        var score = calculator.CalculateTotalScore(test, allTests, date);
                                         var days = test.DueDate.DayNumber - date.DayNumber;
                                         <div class="weekly-test-row">
                                             <div class="weekly-test-info">

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -1,5 +1,6 @@
 @page "/study"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@using WSIST.Engine
 @inherits AuthenticatedComponentBase
 <PageTitle>WSIST — Study</PageTitle>
 
@@ -59,6 +60,31 @@
                             <div class="study-card-bar-bg">
                                 <div class="study-card-bar" style="width: @(score / 40.0 * 100)%"></div>
                             </div>
+
+                            @if (studiedTestId == test.Id)
+                            {
+                                <div class="studied-prompt">
+                                    <span class="studied-prompt-label">How's your understanding now?</span>
+                                    <div class="studied-prompt-row">
+                                        <select class="studied-select" @bind="updatedUnderstanding">
+                                            @foreach (var u in Enum.GetValues<Test.PersonalUnderstanding>())
+                                            {
+                                                <option value="@u">@Test.UnderstandingHelper(u)</option>
+                                            }
+                                        </select>
+                                        <button class="button-primary button-accent" @onclick="() => SaveStudiedUnderstanding(test)">Save</button>
+                                        <button class="button-primary" @onclick="CancelStudiedPrompt">Cancel</button>
+                                    </div>
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="study-card-footer">
+                                    <button class="button-primary studied-btn" @onclick="() => OpenStudiedPrompt(test)">
+                                        ✓ Studied it
+                                    </button>
+                                </div>
+                            }
                         </div>
                     }
                 </div>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -15,6 +15,19 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
     private bool calculated = false;
     private Guid? studiedTestId;
     private Test.PersonalUnderstanding updatedUnderstanding;
+    private bool weeklyMode = false;
+    private Dictionary<DayOfWeek, double> weeklyHours = new()
+    {
+        { DayOfWeek.Monday,    1 },
+        { DayOfWeek.Tuesday,   1 },
+        { DayOfWeek.Wednesday, 1 },
+        { DayOfWeek.Thursday,  1 },
+        { DayOfWeek.Friday,    1 },
+        { DayOfWeek.Saturday,  0 },
+        { DayOfWeek.Sunday,    0 },
+    };
+    private Dictionary<DateOnly, List<Test>> weeklyPlan = [];
+    private bool weeklyCalculated = false;
 
     protected override Task OnAuthenticatedAsync()
     {
@@ -28,6 +41,25 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
         recommendations = calculator.GetStudyRecommendations(allTests, hoursAvailable);
         calculated = true;
     }
+
+    private void CalculateWeekly()
+    {
+        weeklyPlan = calculator.GetWeeklyPlan(allTests, weeklyHours);
+        weeklyCalculated = true;
+    }
+
+    private static string DayLabel(DateOnly date)
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        return date == today ? "Today" : date.ToString("ddd d MMM");
+    }
+
+    private string GetGradeClass(double avg) => avg switch
+    {
+        >= 5 => "grade-good",
+        >= 4 => "grade-ok",
+        _ => "grade-poor"
+    };
 
     private void OpenStudiedPrompt(Test test)
     {

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -13,6 +13,8 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
     private List<Subject> subjects = [];
     private double hoursAvailable = 1;
     private bool calculated = false;
+    private Guid? studiedTestId;
+    private Test.PersonalUnderstanding updatedUnderstanding;
 
     protected override Task OnAuthenticatedAsync()
     {
@@ -25,6 +27,35 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
     {
         recommendations = calculator.GetStudyRecommendations(allTests, hoursAvailable);
         calculated = true;
+    }
+
+    private void OpenStudiedPrompt(Test test)
+    {
+        studiedTestId = test.Id;
+        updatedUnderstanding = test.Understanding;
+    }
+
+    private void CancelStudiedPrompt()
+    {
+        studiedTestId = null;
+    }
+
+    private void SaveStudiedUnderstanding(Test test)
+    {
+        management.TestEditor(
+            test.Id,
+            test.Title,
+            test.Subject,
+            test.DueDate,
+            test.Volume,
+            updatedUnderstanding,
+            test.Grade
+        );
+
+        allTests = management.LoadAllTests(CurrentUserId);
+        recommendations = calculator.GetStudyRecommendations(allTests, hoursAvailable);
+        studiedTestId = null;
+        StateHasChanged();
     }
 
     private string GetScoreBreakdown(Test test)

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -86,6 +86,8 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
 
         allTests = management.LoadAllTests(CurrentUserId);
         recommendations = calculator.GetStudyRecommendations(allTests, hoursAvailable);
+        if (weeklyCalculated)
+            weeklyPlan = calculator.GetWeeklyPlan(allTests, weeklyHours);
         studiedTestId = null;
         StateHasChanged();
     }

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1133,3 +1133,63 @@ a.button-primary[href="/study"]:hover {
     color: var(--text-muted);
     font-weight: 400;
 }
+
+/* ── Post-study feedback ── */
+
+.study-card-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 4px;
+}
+
+.studied-btn {
+    font-size: 12px;
+    padding: 5px 12px;
+    color: var(--text-muted);
+}
+
+.studied-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent-border);
+}
+
+.studied-prompt {
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.studied-prompt-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.studied-prompt-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.studied-select {
+    background: var(--bg);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 7px 10px;
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+    flex: 1;
+    max-width: 180px;
+    appearance: none;
+    transition: border-color var(--transition);
+}
+
+.studied-select:focus {
+    border-color: var(--accent);
+}

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1266,3 +1266,134 @@ a.button-primary[href="/study"]:hover {
 
 .delta-up   { color: #4ade80; }
 .delta-down { color: #f87171; }
+
+/* ── Weekly planner ── */
+
+.study-mode-toggle {
+    display: flex;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 3px;
+    gap: 2px;
+    align-self: flex-start;
+    margin-bottom: 1rem;
+}
+
+.study-mode-btn {
+    background: none;
+    border: none;
+    border-radius: var(--radius-xs);
+    padding: 6px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition);
+    font-family: inherit;
+}
+
+.study-mode-btn.active {
+    background: var(--bg-subtle);
+    color: var(--text-primary);
+}
+
+.study-mode-btn:hover:not(.active) {
+    color: var(--text-primary);
+}
+
+.weekly-hours-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 8px;
+}
+
+.weekly-hours-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.weekly-day-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.weekly-plan {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 2rem;
+}
+
+.weekly-day-block {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.weekly-day-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-subtle);
+}
+
+.weekly-day-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.weekly-day-off {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.weekly-day-tests {
+    display: flex;
+    flex-direction: column;
+}
+
+.weekly-test-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 11px 16px;
+    border-bottom: 1px solid var(--border);
+    gap: 12px;
+}
+
+.weekly-test-row:last-child {
+    border-bottom: none;
+}
+
+.weekly-test-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.weekly-test-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.weekly-test-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.weekly-test-score {
+    font-size: 13px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1193,3 +1193,76 @@ a.button-primary[href="/study"]:hover {
 .studied-select:focus {
     border-color: var(--accent);
 }
+
+/* ── Grade trend chart ── */
+
+.grade-trends {
+    margin-bottom: 2rem;
+}
+
+.grade-trend-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.grade-trend-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: border-color var(--transition);
+}
+
+.grade-trend-card:hover {
+    border-color: var(--border-hover);
+}
+
+.grade-trend-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.grade-trend-subject {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.grade-trend-latest {
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+}
+
+.grade-trend-svg {
+    width: 100%;
+    height: 56px;
+    overflow: visible;
+}
+
+.grade-trend-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.grade-trend-count {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.grade-trend-delta {
+    font-size: 12px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.delta-up   { color: #4ade80; }
+.delta-down { color: #f87171; }

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1080,3 +1080,56 @@ a.button-primary[href="/study"]:hover {
     gap: 8px;
     justify-content: flex-end;
 }
+
+/* ── Missing grade reminders ── */
+
+.missing-grades-strip {
+    background: rgba(245, 158, 11, 0.07);
+    border: 1px solid var(--accent-border);
+    border-radius: var(--radius);
+    padding: 12px 16px;
+    margin-bottom: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+
+.missing-grades-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.missing-grades-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.missing-grade-chip {
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 99px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.missing-grade-chip:hover {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+}
+
+.missing-grade-chip-date {
+    color: var(--text-muted);
+    font-weight: 400;
+}


### PR DESCRIPTION
## Summary

Implements all four Phase 4 features from `wsist-phase4-tasks.md`:

1. **Missing grade reminders** — home page strip listing past tests with no grade entered; clicking a chip opens the edit modal for that test.
2. **Post-study understanding update** — each study card gets a "Studied it" button with an inline prompt to update understanding; recommendations re-run immediately so scores reflect the change.
3. **Grade trend chart** — per-subject SVG sparklines (pure Razor-rendered SVG, no JS chart libraries) for subjects with 2+ graded tests, with guide lines at grades 4/5 and a first-to-latest delta.
4. **Weekly study planner** — Today/This-week toggle on the study page; enter available hours per day and get a 7-day plan driven by `PriorityCalculator.GetWeeklyPlan`.

## Notes

- Added `@using WSIST.Engine` to `Study.razor` (required by the new markup referencing `Test` enums).
- Added `GetGradeClass` to `Study.razor.cs` (weekly plan rows use it; it previously existed only on Home).
- No migrations; `dotnet build` ran clean (0 errors) before each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly study planner that generates a 7‑day plan from per‑day hours
  * Grade trends visualization showing per‑subject progress and deltas
  * Missing grades reminders with quick edit action
  * Study tracking workflow to mark a test as studied and record understanding
  * Toggle between Today and This Week study modes with per‑day planning controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->