### PR TITLE
fix: address full-codebase CodeRabbit review findings (48 fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 /WSIST/WSIST.Web/bin
 /WSIST/WSIST.UnitTests/obj
 /WSIST/WSIST.UnitTests/bin
-WSIST/WSIST.Engine/bin
+/WSIST/WSIST.Engine/bin
 WSIST/WSIST.Web/appsettings.Development.json
 .claude
 .env
-coderabbit-full-review.txt
+coderabbit-full-review*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /WSIST/WSIST.UnitTests/obj
 /WSIST/WSIST.UnitTests/bin
 /WSIST/WSIST.Engine/bin
-WSIST/WSIST.Web/appsettings.Development.json
+/WSIST/WSIST.Web/appsettings.Development.json
 .claude
 .env
 coderabbit-full-review*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@
 /WSIST/WSIST.Web/wwwroot/lib
 /WSIST/WSIST.Web/bin
 /WSIST/WSIST.UnitTests/obj
-/WSIST/WSIST.UnitTests/obj
-WSIST/WSIST.UnitTests/obj/Debug/net9.0/WSIST.UnitTests.csproj.AssemblyReference.cache
-/WSIST/WSIST.UnitTests/obj
 /WSIST/WSIST.UnitTests/bin
 WSIST/WSIST.Engine/bin
 WSIST/WSIST.Web/appsettings.Development.json
+.claude
+.env
+coderabbit-full-review.txt

--- a/WSIST/.config/dotnet-tools.json
+++ b/WSIST/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.2.4",
+      "version": "1.3.0",
       "commands": [
         "csharpier"
       ],

--- a/WSIST/.env.example
+++ b/WSIST/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and customize. Used by docker-compose.yml for the local MySQL container.
+MYSQL_ROOT_PASSWORD=password
+MYSQL_DATABASE=wsistdb

--- a/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.Designer.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WSIST.Engine;
 
@@ -11,9 +12,11 @@ using WSIST.Engine;
 namespace WSIST.Engine.Migrations
 {
     [DbContext(typeof(WsistContext))]
-    partial class WsistContextModelSnapshot : ModelSnapshot
+    [Migration("20260611100206_SubjectIdAutoIncrement")]
+    partial class SubjectIdAutoIncrement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.cs
@@ -39,6 +39,12 @@ namespace WSIST.Engine.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Rollback limitation: if user-created subjects have claimed
+            // auto-increment ids 1..5 since the Up ran, shifting the system
+            // subjects back from -6..-1 to 0..5 would collide with them on the
+            // primary key and this migration would fail. There is no safe,
+            // automatic resolution — those user subjects would have to be
+            // renumbered manually first.
             migrationBuilder.Sql("SET FOREIGN_KEY_CHECKS = 0;");
 
             migrationBuilder.AlterColumn<int>(

--- a/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260611100206_SubjectIdAutoIncrement.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace WSIST.Engine.Migrations
+{
+    /// <inheritdoc />
+    public partial class SubjectIdAutoIncrement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Move the seeded system subjects from ids 0..5 to -6..-1 *in place*
+            // (renumbering instead of delete+insert keeps every Tests.Subject
+            // reference intact), then turn the column into auto-increment so
+            // user-created subjects get database-generated ids. Renumbering must
+            // happen first: MySQL won't accept an auto-increment column that
+            // still holds a 0. FK checks stay off through the ALTER because the
+            // column is referenced by FK_Tests_Subjects_Subject.
+            migrationBuilder.Sql("SET FOREIGN_KEY_CHECKS = 0;");
+            migrationBuilder.Sql("UPDATE `Subjects` SET `Id` = `Id` - 6 WHERE `IsSystem` = 1 AND `Id` BETWEEN 0 AND 5;");
+            migrationBuilder.Sql("UPDATE `Tests` SET `Subject` = `Subject` - 6 WHERE `Subject` BETWEEN 0 AND 5;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Subjects",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.Sql("SET FOREIGN_KEY_CHECKS = 1;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("SET FOREIGN_KEY_CHECKS = 0;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Subjects",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.Sql("UPDATE `Subjects` SET `Id` = `Id` + 6 WHERE `IsSystem` = 1 AND `Id` BETWEEN -6 AND -1;");
+            migrationBuilder.Sql("UPDATE `Tests` SET `Subject` = `Subject` + 6 WHERE `Subject` BETWEEN -6 AND -1;");
+            migrationBuilder.Sql("SET FOREIGN_KEY_CHECKS = 1;");
+        }
+    }
+}

--- a/WSIST/WSIST.Engine/Test.cs
+++ b/WSIST/WSIST.Engine/Test.cs
@@ -65,9 +65,9 @@ public class Test
         return "Please Choose a Setting";
     }
 
-    public static string UnderstandingHelper(PersonalUnderstanding volume)
+    public static string UnderstandingHelper(PersonalUnderstanding understanding)
     {
-        switch (volume)
+        switch (understanding)
         {
             case PersonalUnderstanding.VeryLow:
             {

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -16,6 +16,7 @@ public class TestManagement
     {
         if (string.IsNullOrWhiteSpace(title))
             throw new ArgumentException("Title cannot be empty.", nameof(title));
+        EnsureSubjectAccessible(subjectId, userId);
 
         var test = new Test
         {
@@ -37,6 +38,7 @@ public class TestManagement
     {
         if (string.IsNullOrWhiteSpace(title))
             throw new ArgumentException("Title cannot be empty.", nameof(title));
+        EnsureSubjectAccessible(subjectId, userId);
 
         var test = context.Tests.Find(id);
         // Only the owner may edit a test.
@@ -59,6 +61,16 @@ public class TestManagement
         context.Tests.Remove(test);
         context.SaveChanges();
     }
+    private void EnsureSubjectAccessible(int subjectId, int userId)
+    {
+        // A test may only reference a system subject or one of the user's own
+        // custom subjects — never another user's subject.
+        var accessible = context.Subjects
+            .Any(s => s.Id == subjectId && (s.IsSystem || s.UserId == userId));
+        if (!accessible)
+            throw new ArgumentException("Subject does not exist or is not accessible.", nameof(subjectId));
+    }
+
     public List<Subject> GetSubjectsForUser(int userId)
     {
         return context.Subjects
@@ -138,8 +150,11 @@ public class TestManagement
         {
             // A concurrent request created the same user between our check and
             // the insert (unique index on Email) — fetch the winner instead.
+            // If no row exists, the failure had another cause; surface it.
             context.ChangeTracker.Clear();
-            return context.Users.First(u => u.Email == email);
+            var existing = context.Users.FirstOrDefault(u => u.Email == email);
+            if (existing is null) throw;
+            return existing;
         }
     }
 

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -14,6 +14,9 @@ public class TestManagement
     public void NewTestMaker(string title, int subjectId, DateOnly dueDate,
         Test.TestVolume volume, Test.PersonalUnderstanding understanding, double? grade, int userId)
     {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty.", nameof(title));
+
         var test = new Test
         {
             Id = Guid.NewGuid(),
@@ -30,10 +33,14 @@ public class TestManagement
     }
 
     public void TestEditor(Guid id, string title, int subjectId, DateOnly dueDate,
-        Test.TestVolume volume, Test.PersonalUnderstanding understanding, double? grade)
+        Test.TestVolume volume, Test.PersonalUnderstanding understanding, double? grade, int userId)
     {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty.", nameof(title));
+
         var test = context.Tests.Find(id);
-        if (test is null) return;
+        // Only the owner may edit a test.
+        if (test is null || test.UserId != userId) return;
 
         test.Title = title;
         test.Subject = subjectId;
@@ -44,10 +51,11 @@ public class TestManagement
         context.SaveChanges();
     }
 
-    public void TestRemover(Guid id)
+    public void TestRemover(Guid id, int userId)
     {
         var test = context.Tests.Find(id);
-        if (test is null) return;
+        // Only the owner may delete a test.
+        if (test is null || test.UserId != userId) return;
         context.Tests.Remove(test);
         context.SaveChanges();
     }
@@ -62,10 +70,12 @@ public class TestManagement
 
     public void AddCustomSubject(string name, int userId)
     {
-        var nextId = context.Subjects.Any() ? context.Subjects.Max(s => s.Id) + 1 : 6;
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Subject name cannot be empty.", nameof(name));
+
+        // Id is database-generated (auto-increment) — see WsistContext.
         var subject = new Subject
         {
-            Id = nextId,
             Name = name,
             IsSystem = false,
             UserId = userId
@@ -93,27 +103,44 @@ public class TestManagement
 
     public void UpdateDisplayName(int userId, string displayName)
     {
+        var trimmed = displayName.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            throw new ArgumentException("Display name cannot be empty.", nameof(displayName));
+
         var user = context.Users.Find(userId);
         if (user is null) return;
-        user.DisplayName = displayName.Trim();
+        user.DisplayName = trimmed;
         context.SaveChanges();
     }
 
     public User GetOrCreateUser(string email, string displayName, string googleId)
     {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email cannot be empty.", nameof(email));
+
         var user = context.Users.FirstOrDefault(u => u.Email == email);
         if (user is not null) return user;
 
-        user = new User
+        try
         {
-            Email = email,
-            DisplayName = displayName,
-            GoogleId = googleId,
-            CreatedAt = DateTime.UtcNow
-        };
-        context.Users.Add(user);
-        context.SaveChanges();
-        return user;
+            user = new User
+            {
+                Email = email,
+                DisplayName = displayName,
+                GoogleId = googleId,
+                CreatedAt = DateTime.UtcNow
+            };
+            context.Users.Add(user);
+            context.SaveChanges();
+            return user;
+        }
+        catch (Microsoft.EntityFrameworkCore.DbUpdateException)
+        {
+            // A concurrent request created the same user between our check and
+            // the insert (unique index on Email) — fetch the winner instead.
+            context.ChangeTracker.Clear();
+            return context.Users.First(u => u.Email == email);
+        }
     }
 
     public void DeleteUser(int userId)

--- a/WSIST/WSIST.Engine/User.cs
+++ b/WSIST/WSIST.Engine/User.cs
@@ -6,6 +6,8 @@ public class User
     public string Email { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
     public string GoogleId { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
+    // Default so a User created without an explicit timestamp never persists
+    // DateTime.MinValue (0001-01-01).
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public ICollection<Test> Tests { get; set; } = [];
 }

--- a/WSIST/WSIST.Engine/WSIST.Engine.csproj
+++ b/WSIST/WSIST.Engine/WSIST.Engine.csproj
@@ -1,13 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <!-- EF Core is held at 9.x because Pomelo.EntityFrameworkCore.MySql has no
+         EF Core 10-compatible release yet (latest stable is 9.0.0). EF Core 9
+         runs fine on net10.0. Bump all four together once Pomelo ships 10.x. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.17" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/WSIST/WSIST.Engine/WsistContext.cs
+++ b/WSIST/WSIST.Engine/WsistContext.cs
@@ -37,7 +37,10 @@ public class WsistContext : DbContext
         {
             entity.ToTable("Subjects");
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.Id).ValueGeneratedNever();
+            // User subjects get database-generated (auto-increment) ids; the
+            // seeded system subjects live on negative ids so the two ranges
+            // can never collide.
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
             entity.Property(e => e.Name).HasMaxLength(100).IsRequired();
             entity.Property(e => e.IsSystem).HasDefaultValue(false);
 
@@ -48,12 +51,12 @@ public class WsistContext : DbContext
                 .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasData(
-                new Subject { Id = 0, Name = "Math", IsSystem = true },
-                new Subject { Id = 1, Name = "English", IsSystem = true },
-                new Subject { Id = 2, Name = "French", IsSystem = true },
-                new Subject { Id = 3, Name = "German", IsSystem = true },
-                new Subject { Id = 4, Name = "Chemistry", IsSystem = true },
-                new Subject { Id = 5, Name = "Other", IsSystem = true }
+                new Subject { Id = -6, Name = "Math", IsSystem = true },
+                new Subject { Id = -5, Name = "English", IsSystem = true },
+                new Subject { Id = -4, Name = "French", IsSystem = true },
+                new Subject { Id = -3, Name = "German", IsSystem = true },
+                new Subject { Id = -2, Name = "Chemistry", IsSystem = true },
+                new Subject { Id = -1, Name = "Other", IsSystem = true }
             );
         });
 

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -71,7 +71,7 @@ public class UnitTests
 
         //act
         var test = manager.LoadAllTests(user.Id).First();
-        manager.TestRemover(test.Id);
+        manager.TestRemover(test.Id, user.Id);
 
         //assert
         Assert.That(manager.LoadAllTests(user.Id).Any(t => t.Id == test.Id), Is.False);
@@ -186,17 +186,19 @@ public class UnitTests
         context.Users.Add(otherUser);
         context.SaveChanges();
 
-        // HasData seeding doesn't run for in-memory DB, so seed manually
+        // HasData seeding doesn't run for in-memory DB, so seed manually.
+        // System subjects live on negative ids (see WsistContext) so they can
+        // never collide with the provider-generated ids of custom subjects.
         context.Subjects.AddRange(
             new Subject
             {
-                Id = 0,
+                Id = -6,
                 Name = "Math",
                 IsSystem = true,
             },
             new Subject
             {
-                Id = 1,
+                Id = -5,
                 Name = "English",
                 IsSystem = true,
             }
@@ -253,6 +255,105 @@ public class UnitTests
             },
         };
         Assert.That(calculator.CalculateGradeScore(0, tests), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void TestRemover_RefusesToDeleteAnotherUsersTest()
+    {
+        //arrange
+        using var context = CreateContext();
+        var owner = SeedUser(context);
+        var attacker = new User
+        {
+            Email = "attacker@example.com",
+            DisplayName = "Attacker",
+            GoogleId = "google-999",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(attacker);
+        context.SaveChanges();
+
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Owner's Test",
+            0,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            owner.Id
+        );
+        var test = manager.LoadAllTests(owner.Id).First();
+
+        //act — attacker tries to delete the owner's test
+        manager.TestRemover(test.Id, attacker.Id);
+
+        //assert
+        Assert.That(manager.LoadAllTests(owner.Id).Any(t => t.Id == test.Id));
+    }
+
+    [Test]
+    public void TestEditor_RefusesToEditAnotherUsersTest()
+    {
+        //arrange
+        using var context = CreateContext();
+        var owner = SeedUser(context);
+        var attacker = new User
+        {
+            Email = "attacker@example.com",
+            DisplayName = "Attacker",
+            GoogleId = "google-999",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(attacker);
+        context.SaveChanges();
+
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Original Title",
+            0,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            owner.Id
+        );
+        var test = manager.LoadAllTests(owner.Id).First();
+
+        //act — attacker tries to edit the owner's test
+        manager.TestEditor(
+            test.Id,
+            "Hijacked Title",
+            test.Subject,
+            test.DueDate,
+            test.Volume,
+            test.Understanding,
+            test.Grade,
+            attacker.Id
+        );
+
+        //assert
+        Assert.That(manager.LoadAllTests(owner.Id).First().Title, Is.EqualTo("Original Title"));
+    }
+
+    [Test]
+    public void NewTestMaker_RejectsEmptyTitle()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var manager = new TestManagement(context);
+
+        //act + assert
+        Assert.Throws<ArgumentException>(() => manager.NewTestMaker(
+            "   ",
+            0,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            user.Id
+        ));
     }
 
     [Test]

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -28,18 +28,36 @@ public class UnitTests
         return user;
     }
 
+    private static int SeedSystemSubject(WsistContext context, string name = "Math")
+    {
+        // HasData seeding doesn't run for the in-memory provider, and the
+        // engine now validates that a test's subject exists and is accessible,
+        // so tests must seed a subject explicitly. System subjects live on
+        // negative ids (see WsistContext).
+        var subject = new Subject
+        {
+            Id = -6,
+            Name = name,
+            IsSystem = true,
+        };
+        context.Subjects.Add(subject);
+        context.SaveChanges();
+        return subject.Id;
+    }
+
     [Test]
     public void TestIfNewTestGetsMade()
     {
         //arrange
         using var context = CreateContext();
         var user = SeedUser(context);
+        var subjectId = SeedSystemSubject(context);
         var manager = new TestManagement(context);
 
         //act
         manager.NewTestMaker(
             "Math Test",
-            0, // was Test.Subjects.Math
+            subjectId,
             new DateOnly(2026, 12, 01),
             Test.TestVolume.VeryHigh,
             Test.PersonalUnderstanding.VeryLow,
@@ -57,11 +75,12 @@ public class UnitTests
         //arrange
         using var context = CreateContext();
         var user = SeedUser(context);
+        var subjectId = SeedSystemSubject(context, "German");
         var manager = new TestManagement(context);
 
         manager.NewTestMaker(
             "Test To Delete",
-            3, // was Test.Subjects.German
+            subjectId,
             new DateOnly(2026, 12, 01),
             Test.TestVolume.Low,
             Test.PersonalUnderstanding.High,
@@ -78,7 +97,7 @@ public class UnitTests
     }
 
     [Test]
-    public static void CheckIfGradeIsNotNullIfInThePast()
+    public void CheckIfGradeIsNotNullIfInThePast()
     {
         //arrange
         DateOnly dueDate = new DateOnly(2025, 06, 07);
@@ -92,7 +111,7 @@ public class UnitTests
     }
 
     [Test]
-    public static void CheckIfGradeIsNullIfInTheFuture()
+    public void CheckIfGradeIsNullIfInTheFuture()
     {
         //arrange
         DateOnly dueDate = new DateOnly(2030, 06, 07);
@@ -220,7 +239,7 @@ public class UnitTests
     }
 
     [Test]
-    public static void GradeScoreGivesFullPushBelowAverageOfFour()
+    public void GradeScoreGivesFullPushBelowAverageOfFour()
     {
         var calculator = new PriorityCalculator();
         var tests = new List<Test>
@@ -236,12 +255,12 @@ public class UnitTests
         Assert.That(
             calculator.CalculateGradeScore(0, tests),
             Is.EqualTo(6),
-            "An average below 3 must earn the full +6 push, not 0."
+            "An average below 4 must earn the full +6 push, not 0."
         );
     }
 
     [Test]
-    public static void GradeScoreGivesSmallPushForStrongAverage()
+    public void GradeScoreGivesSmallPushForStrongAverage()
     {
         var calculator = new PriorityCalculator();
         var tests = new List<Test>
@@ -272,11 +291,12 @@ public class UnitTests
         };
         context.Users.Add(attacker);
         context.SaveChanges();
+        var subjectId = SeedSystemSubject(context);
 
         var manager = new TestManagement(context);
         manager.NewTestMaker(
             "Owner's Test",
-            0,
+            subjectId,
             new DateOnly(2026, 12, 01),
             Test.TestVolume.Medium,
             Test.PersonalUnderstanding.Medium,
@@ -307,11 +327,12 @@ public class UnitTests
         };
         context.Users.Add(attacker);
         context.SaveChanges();
+        var subjectId = SeedSystemSubject(context);
 
         var manager = new TestManagement(context);
         manager.NewTestMaker(
             "Original Title",
-            0,
+            subjectId,
             new DateOnly(2026, 12, 01),
             Test.TestVolume.Medium,
             Test.PersonalUnderstanding.Medium,
@@ -353,6 +374,38 @@ public class UnitTests
             Test.PersonalUnderstanding.Medium,
             null,
             user.Id
+        ));
+    }
+
+    [Test]
+    public void NewTestMaker_RejectsAnotherUsersSubject()
+    {
+        //arrange
+        using var context = CreateContext();
+        var owner = SeedUser(context);
+        var attacker = new User
+        {
+            Email = "attacker@example.com",
+            DisplayName = "Attacker",
+            GoogleId = "google-999",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(attacker);
+        context.SaveChanges();
+
+        var manager = new TestManagement(context);
+        manager.AddCustomSubject("Owner's Subject", owner.Id);
+        var subjectId = manager.GetSubjectsForUser(owner.Id).First(s => !s.IsSystem).Id;
+
+        //act + assert — attacker may not file tests under the owner's subject
+        Assert.Throws<ArgumentException>(() => manager.NewTestMaker(
+            "Sneaky Test",
+            subjectId,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            attacker.Id
         ));
     }
 

--- a/WSIST/WSIST.UnitTests/WSIST.UnitTests.csproj
+++ b/WSIST/WSIST.UnitTests/WSIST.UnitTests.csproj
@@ -7,10 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <!-- InMemory provider tracks the EF Core 9.x line used by WSIST.Engine. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.17" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WSIST/WSIST.Web/Components/App.razor
+++ b/WSIST/WSIST.Web/Components/App.razor
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous"/>
     <link rel="stylesheet" href="app.css"/>
     <link rel="stylesheet" href="WSIST.Web.styles.css"/>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,340..640;1,9..144,340..640&family=Schibsted+Grotesk:ital,wght@0,400..900;1,400..900&family=Spline+Sans+Mono:wght@400..600&display=swap" rel="stylesheet"/>

--- a/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
+++ b/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
@@ -27,7 +27,13 @@ public abstract class AuthenticatedComponentBase(
         var name = user.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown";
         var googleId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "";
 
-        if (email is null) return;
+        if (email is null)
+        {
+            // Without an email we can't resolve a user; treat the session as
+            // unauthenticated instead of leaving CurrentUserId at 0.
+            navigation.NavigateTo("/login-page", forceLoad: true);
+            return;
+        }
 
         var dbUser = management.GetOrCreateUser(email, name, googleId);
         CurrentUserId = dbUser.Id;
@@ -36,4 +42,12 @@ public abstract class AuthenticatedComponentBase(
     }
 
     protected virtual Task OnAuthenticatedAsync() => Task.CompletedTask;
+
+    // Shared grade-to-CSS mapping used by the dashboard and study pages.
+    protected static string GetGradeClass(double avg) => avg switch
+    {
+        >= 5 => "grade-good",
+        >= 4 => "grade-ok",
+        _ => "grade-poor"
+    };
 }

--- a/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
+++ b/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
@@ -35,8 +35,18 @@ public abstract class AuthenticatedComponentBase(
             return;
         }
 
-        var dbUser = management.GetOrCreateUser(email, name, googleId);
-        CurrentUserId = dbUser.Id;
+        try
+        {
+            var dbUser = management.GetOrCreateUser(email, name, googleId);
+            CurrentUserId = dbUser.Id;
+        }
+        catch (Exception)
+        {
+            // Database unavailable or user resolution failed — send the user
+            // to the error page instead of crashing the circuit.
+            navigation.NavigateTo("/Error", forceLoad: true);
+            return;
+        }
 
         await OnAuthenticatedAsync();
     }

--- a/WSIST/WSIST.Web/Components/Pages/Error.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Error.razor
@@ -5,7 +5,7 @@
 
 <div class="error-page">
     <div class="error-content">
-        <span class="error-icon">⚠</span>
+        <span class="error-icon" aria-hidden="true">⚠</span>
         <h1 class="error-title">Something went wrong</h1>
         <p class="error-sub">An unexpected error occurred. If this keeps happening, try logging out and back in.</p>
         <a href="/" class="button-primary button-accent" data-enhance-nav="false">← Back to home</a>

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -12,7 +12,7 @@
         </div>
         <button class="button-primary" @onclick="Refresh">↻</button>
         <a href="/settings" class="button-primary" data-enhance-nav="false">Settings</a>
-        <a href="/study" class="button-primary" data-enhance-nav="false">Study →</a>
+        <a href="/study" class="button-primary button-accent" data-enhance-nav="false">Study →</a>
         <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
     </div>
 
@@ -61,7 +61,7 @@
                                 @(subjects.FirstOrDefault(s => s.Id == topRecommendation.Subject)?.Name ?? "Unknown") · in @days day@(days == 1 ? "" : "s") · @score/40 pts
                             </div>
                         </div>
-                        <a href="/study" class="button-primary" data-enhance-nav="false" style="flex-shrink:0">Full plan →</a>
+                        <a href="/study" class="button-primary button-accent" data-enhance-nav="false" style="flex-shrink:0">Full plan →</a>
                     </div>
                     <div class="study-card-bar-bg">
                         <div class="study-card-bar" style="width: @(score / 40.0 * 100)%"></div>
@@ -219,7 +219,7 @@
                         </div>
                         <div class="form-group">
                             <label>Due date</label>
-                            <input type="date" @bind="@temporaryTest.DueDate" @bind:event="oninput"/>
+                            <input type="date" @bind="@temporaryTest.DueDate"/>
                         </div>
                         <div class="form-group">
                             <label>Volume</label>

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -153,12 +153,8 @@
                         const int pad = 8;
                         int pts = history.Count;
 
-                        // Map grades (1–6) to Y coords — higher grade = lower Y value (top of SVG)
-                        string ToY(double g) => ((h - pad) - ((g - 1) / 5.0 * (h - pad * 2))).ToString("F1");
-                        string ToX(int i) => (pad + i * (double)(w - pad * 2) / (pts - 1)).ToString("F1");
-
-                        var points = string.Join(" ", history.Select((item, i) => $"{ToX(i)},{ToY(item.Grade)}"));
-                        var dotPoints = history.Select((item, i) => (X: ToX(i), Y: ToY(item.Grade), Grade: item.Grade)).ToList();
+                        var points = string.Join(" ", history.Select((item, i) => $"{MapIndexToX(i, pts, w, pad)},{MapGradeToY(item.Grade, h, pad)}"));
+                        var dotPoints = history.Select((item, i) => (X: MapIndexToX(i, pts, w, pad), Y: MapGradeToY(item.Grade, h, pad), Grade: item.Grade)).ToList();
 
                         <div class="grade-trend-card">
                             <div class="grade-trend-header">
@@ -167,9 +163,9 @@
                             </div>
                             <svg viewBox="0 0 @w @h" class="grade-trend-svg" preserveAspectRatio="none">
                                 <!-- Guide lines at grades 4 and 5 -->
-                                <line x1="@pad" y1="@ToY(4)" x2="@(w - pad)" y2="@ToY(4)"
+                                <line x1="@pad" y1="@MapGradeToY(4, h, pad)" x2="@(w - pad)" y2="@MapGradeToY(4, h, pad)"
                                       stroke="var(--border)" stroke-width="1" stroke-dasharray="3,3"/>
-                                <line x1="@pad" y1="@ToY(5)" x2="@(w - pad)" y2="@ToY(5)"
+                                <line x1="@pad" y1="@MapGradeToY(5, h, pad)" x2="@(w - pad)" y2="@MapGradeToY(5, h, pad)"
                                       stroke="var(--border)" stroke-width="1" stroke-dasharray="3,3"/>
                                 <!-- Grade line -->
                                 <polyline points="@points"

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -68,12 +68,13 @@ public partial class Home(
             );
     }
 
-    private string GetGradeClass(double avg) => avg switch
-    {
-        >= 5 => "grade-good",
-        >= 4 => "grade-ok",
-        _ => "grade-poor"
-    };
+    // Map a grade (1–6) to an SVG Y coordinate — higher grade = lower Y (top of SVG).
+    private static string MapGradeToY(double grade, int height, int padding) =>
+        ((height - padding) - ((grade - 1) / 5.0 * (height - padding * 2))).ToString("F1");
+
+    // Map a point index to an SVG X coordinate, spreading points across the width.
+    private static string MapIndexToX(int index, int totalPoints, int width, int padding) =>
+        (padding + index * (double)(width - padding * 2) / (totalPoints - 1)).ToString("F1");
 
     public enum Modes
     {
@@ -138,7 +139,8 @@ public partial class Home(
                     temporaryTest.DueDate,
                     temporaryTest.Volume,
                     temporaryTest.Understanding,
-                    temporaryTest.Grade
+                    temporaryTest.Grade,
+                    CurrentUserId
                 );
                 break;
             }
@@ -168,7 +170,7 @@ public partial class Home(
 
     private void DeleteTest(Guid id)
     {
-        management.TestRemover(id);
+        management.TestRemover(id, CurrentUserId);
         Refresh();
     }
 }

--- a/WSIST/WSIST.Web/Components/Pages/NotFound.razor
+++ b/WSIST/WSIST.Web/Components/Pages/NotFound.razor
@@ -5,7 +5,7 @@
 
 <div class="error-page">
     <div class="error-content">
-        <span class="error-icon">🔍</span>
+        <span class="error-icon" aria-hidden="true">🔍</span>
         <h1 class="error-title">Page not found</h1>
         <p class="error-sub">The page you're looking for doesn't exist or has been moved.</p>
         <a href="/" class="button-primary button-accent" data-enhance-nav="false">← Back to home</a>

--- a/WSIST/WSIST.Web/Components/Pages/NotFound.razor
+++ b/WSIST/WSIST.Web/Components/Pages/NotFound.razor
@@ -1,0 +1,13 @@
+@page "/not-found"
+@layout EmptyLayout
+@using WSIST.Web.Components.Layout
+<PageTitle>Page not found – WSIST</PageTitle>
+
+<div class="error-page">
+    <div class="error-content">
+        <span class="error-icon">🔍</span>
+        <h1 class="error-title">Page not found</h1>
+        <p class="error-sub">The page you're looking for doesn't exist or has been moved.</p>
+        <a href="/" class="button-primary button-accent" data-enhance-nav="false">← Back to home</a>
+    </div>
+</div>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -54,13 +54,6 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
         return date == today ? "Today" : date.ToString("ddd d MMM");
     }
 
-    private string GetGradeClass(double avg) => avg switch
-    {
-        >= 5 => "grade-good",
-        >= 4 => "grade-ok",
-        _ => "grade-poor"
-    };
-
     private void OpenStudiedPrompt(Test test)
     {
         studiedTestId = test.Id;
@@ -81,7 +74,8 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
             test.DueDate,
             test.Volume,
             updatedUnderstanding,
-            test.Grade
+            test.Grade,
+            CurrentUserId
         );
 
         allTests = management.LoadAllTests(CurrentUserId);

--- a/WSIST/WSIST.Web/Components/Routes.razor
+++ b/WSIST/WSIST.Web/Components/Routes.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
+﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)"/>
         <FocusOnNavigate RouteData="routeData" Selector="h1"/>

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 
@@ -63,7 +63,7 @@ app.Use(async (context, next) =>
 {
     var isAuthenticated = context.User?.Identity?.IsAuthenticated ?? false;
     var protectedPaths = new[] { "/", "/study", "/settings" };
-    if (protectedPaths.Contains(context.Request.Path.Value) && !isAuthenticated)
+    if (protectedPaths.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase) && !isAuthenticated)
     {
         context.Response.Redirect("/login-page");
         return;
@@ -92,6 +92,8 @@ app.MapGet("/api/grades", async (HttpContext ctx, TestManagement management) =>
     var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
     if (email is null) return Results.Unauthorized();
 
+    // Users are keyed by their (unique) email; GoogleId is informational
+    // only, so a missing NameIdentifier claim simply stores an empty value.
     var user = management.GetOrCreateUser(
         email,
         ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",

--- a/WSIST/WSIST.Web/WSIST.Web.csproj
+++ b/WSIST/WSIST.Web/WSIST.Web.csproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WSIST.Engine\WSIST.Engine.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/WSIST/WSIST.Web/appsettings.json
+++ b/WSIST/WSIST.Web/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "DatabaseConnection": "Server=localhost; Database=wsistdb; Uid=root; Pwd=root;"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -367,19 +367,15 @@ h1:focus {
     transform: scale(0.97);
 }
 
-/* Accent (CTA) button */
-.button-primary.button-accent,
-a.button-primary[href="/login"],
-a.button-primary[href="/study"] {
+/* Accent (CTA) button — opt in with the .button-accent class */
+.button-primary.button-accent {
     background: var(--accent);
     color: #0c0b08;
     border-color: transparent;
     font-weight: 600;
 }
 
-.button-primary.button-accent:hover,
-a.button-primary[href="/login"]:hover,
-a.button-primary[href="/study"]:hover {
+.button-primary.button-accent:hover {
     background: var(--accent-hover);
     border-color: transparent;
 }

--- a/WSIST/WSIST.Web/wwwroot/landing.css
+++ b/WSIST/WSIST.Web/wwwroot/landing.css
@@ -8,8 +8,13 @@
    can leak into the dashboard (app.css).
    ============================================================ */
 
-html{
+/* Only smooth-scroll when the landing page is on screen, so the rule
+   can't leak into the dashboard. */
+html:has(.landing){
   scroll-behavior:smooth;
+}
+
+html{
   -webkit-text-size-adjust:100%;
 }
 

--- a/WSIST/WSIST.Web/wwwroot/landing.css
+++ b/WSIST/WSIST.Web/wwwroot/landing.css
@@ -9,7 +9,9 @@
    ============================================================ */
 
 /* Only smooth-scroll when the landing page is on screen, so the rule
-   can't leak into the dashboard. */
+   can't leak into the dashboard. :has() is supported by all evergreen
+   browsers (Chrome 105+, Safari 15.4+, Firefox 121+); older ones simply
+   fall back to instant scrolling — a harmless degradation. */
 html:has(.landing){
   scroll-behavior:smooth;
 }

--- a/WSIST/WSIST.Web/wwwroot/landing.js
+++ b/WSIST/WSIST.Web/wwwroot/landing.js
@@ -72,11 +72,8 @@
     return 0;
   }
 
-  /* NOTE: the C# engine currently returns 0 for an average below 3
-     (the `_ => 0` branch). That contradicts the product's own rule —
-     "struggling subjects get a push" — so this demo uses the intended
-     mapping: anything under 4 earns the full +6. One-line fix in
-     PriorityCalculator.CalculateGradeScore: change `_ => 0` to `_ => 6`. */
+  /* Mirrors PriorityCalculator.CalculateGradeScore in the C# engine:
+     anything under an average of 4 earns the full +6 push. */
   function gradeScore(avg){
     if (avg >= 5) return 2;
     if (avg >= 4) return 4;
@@ -175,7 +172,7 @@
         setTimeout(function(){
           verdict.textContent = vText;
           verdict.classList.remove("swap");
-        }, 160);
+        }, 250); // match the .25s opacity transition on the verdict element
       }
     }
   }

--- a/WSIST/docker-compose.yml
+++ b/WSIST/docker-compose.yml
@@ -1,17 +1,19 @@
+# Local development database. Defaults are for local use only — never use them
+# in shared or production environments. Copy .env.example to .env to override.
 services:
   mysql:
     image: mysql:8.0
     container_name: wsist-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: wsistdb
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-password}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-wsistdb}
     ports:
       - "3306:3306"
     volumes:
       - wsist-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-ppassword"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$$MYSQL_ROOT_PASSWORD"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/WSIST/docs/design/wsist-landing.html
+++ b/WSIST/docs/design/wsist-landing.html
@@ -1348,11 +1348,8 @@ footer{
     return 0;
   }
 
-  /* NOTE: the C# engine currently returns 0 for an average below 3
-     (the `_ => 0` branch). That contradicts the product's own rule —
-     "struggling subjects get a push" — so this demo uses the intended
-     mapping: anything under 4 earns the full +6. One-line fix in
-     PriorityCalculator.CalculateGradeScore: change `_ => 0` to `_ => 6`. */
+  /* Mirrors PriorityCalculator.CalculateGradeScore in the C# engine:
+     anything under an average of 4 earns the full +6 push. */
   function gradeScore(avg){
     if (avg >= 5) return 2;
     if (avg >= 4) return 4;
@@ -1451,7 +1448,7 @@ footer{
         setTimeout(function(){
           verdict.textContent = vText;
           verdict.classList.remove("swap");
-        }, 160);
+        }, 250); /* match the .25s opacity transition on the verdict element */
       }
     }
   }

--- a/WSIST/nixpacks.toml
+++ b/WSIST/nixpacks.toml
@@ -1,4 +1,7 @@
-﻿[phases.setup]
+# dotnet-sdk_10 on nixos-unstable currently resolves to 10.0.203 (newer patch
+# than global.json's 10.0.201) — that's fine: global.json sets
+# rollForward=latestMinor, which accepts any newer 10.x SDK.
+[phases.setup]
 nixPkgs = ["dotnet-sdk_10"]
 nixLibs = []
 nixpkgsArchive = "nixos-unstable"

--- a/WSIST/nixpacks.toml
+++ b/WSIST/nixpacks.toml
@@ -1,6 +1,6 @@
-# dotnet-sdk_10 on nixos-unstable currently resolves to 10.0.203 (newer patch
-# than global.json's 10.0.201) — that's fine: global.json sets
-# rollForward=latestMinor, which accepts any newer 10.x SDK.
+# dotnet-sdk_10 on nixos-unstable resolves to whatever 10.x patch is current
+# there (typically newer than global.json's 10.0.201) — that's fine:
+# global.json sets rollForward=latestMinor, which accepts any newer 10.x SDK.
 [phases.setup]
 nixPkgs = ["dotnet-sdk_10"]
 nixLibs = []

--- a/docs/landing-implementation.md
+++ b/docs/landing-implementation.md
@@ -1,5 +1,10 @@
 # WSIST — Landing Page & Amber Re-theme Implementation
 
+> **Status: Completed.** The "Design tokens (canonical)" table below is the
+> single source of truth for brand colors (accent: `#f5b342`). Older task
+> files (`wsist-redesign-tasks.md`, `wsist-phase3-tasks.md`) reference
+> superseded values.
+
 Task file for autonomous execution. Work top to bottom; tasks are ordered
 lowest-risk first. Commit after each task with the given message. Run
 `dotnet build` after every task and `dotnet test` after T1.

--- a/docs/wsist-housekeeping-tasks.md
+++ b/docs/wsist-housekeeping-tasks.md
@@ -135,24 +135,25 @@ If for any reason the file is missing, create `WSIST/docker-compose.yml`:
 
 ```yaml
 services:
-  db:
+  mysql:
     image: mysql:8.0
-    container_name: wsist-db
+    container_name: wsist-mysql
+    restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: wsistdb
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-password}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-wsistdb}
     ports:
       - "3306:3306"
     volumes:
-      - wsist-db-data:/var/lib/mysql
+      - wsist-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 5s
-      timeout: 3s
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$$MYSQL_ROOT_PASSWORD"]
+      interval: 10s
+      timeout: 5s
       retries: 10
 
 volumes:
-  wsist-db-data:
+  wsist-mysql-data:
 ```
 
 ### Step 2 — Archive completed task files

--- a/docs/wsist-phase3-tasks.md
+++ b/docs/wsist-phase3-tasks.md
@@ -1,5 +1,10 @@
 # WSIST — Phase 3 Task File (Claude Fable 5)
 
+> **Status: Completed (historical).** This spec predates the amber re-theme.
+> Color values in this file (e.g. the blue `#5b8cff`) are outdated — the
+> canonical design tokens live in `docs/landing-implementation.md`
+> (accent: `#f5b342`).
+
 ## Instructions for the model
 
 Work through every task in the order listed. Do not stop to ask for clarification — every decision is specified below. Commit after each task using the exact message provided. If a file already exists, edit it in place rather than replacing it. Run `dotnet build` before each commit to confirm no compilation errors.

--- a/docs/wsist-redesign-tasks.md
+++ b/docs/wsist-redesign-tasks.md
@@ -1,5 +1,9 @@
 # WSIST — Full Redesign Task File
 
+> **Status: Completed (historical). Superseded by `docs/landing-implementation.md`.**
+> The amber accent used in this file (`#f59e0b`) was later replaced by the
+> canonical `#f5b342` defined in the landing-implementation design tokens.
+
 ## Context for the model
 
 WSIST is a Blazor Server app styled with plain CSS in `app.css`. There is no Tailwind, no React, no npm. Launch UI is used as **visual reference only** — translate its design language into hand-crafted CSS. Do not attempt to install any npm packages or import React components.


### PR DESCRIPTION
## Summary

Resolves all findings from three rounds of full-codebase CodeRabbit review (29 + 19 + 2 findings; 1 deliberately declined, see below).

### Security
- Ownership checks: `TestEditor` / `TestRemover` refuse to touch another user's test
- Subject accessibility: tests may only reference system subjects or the caller's own custom subjects
- Removed hardcoded DB credentials from `appsettings.json` (local dev uses gitignored `appsettings.Development.json`; prod uses Railway env vars)
- `docker-compose.yml` password via `${MYSQL_ROOT_PASSWORD}` env var (+ `.env.example`)
- SRI integrity hash on the Bootstrap CDN link (hash computed and verified against the CDN)
- Case-insensitive protected-path matching in the auth middleware

### Robustness
- Race-safe `GetOrCreateUser` (unique-email collision recovery, rethrows on unrelated failures)
- `AuthenticatedComponentBase` redirects to `/Error` instead of crashing the Blazor circuit when user resolution fails; null-email sessions are treated as unauthenticated
- Input validation across `TestManagement` (empty titles, subject names, display names, emails)
- New `NotFound` page wired via .NET 10 `Router NotFoundPage`
- `User.CreatedAt` defaults to `DateTime.UtcNow`

### Schema migration ⚠️
**`SubjectIdAutoIncrement` runs on prod at startup when this deploys.** It renumbers the six seeded system subjects from ids 0..5 to -6..-1 *in place* (keeping all `Tests.Subject` FK references intact) and converts `Subjects.Id` to auto-increment so user-created subjects get DB-generated ids. Verified against a local MySQL instance: renumbering correct, no orphaned FK rows, auto-increment continues from the next free id. Rollback limitation is documented in the migration.

### Misc
- Static `[Test]` methods converted to instance; new tests for ownership checks, empty-title rejection, and cross-user subject rejection (16/16 pass)
- Accent button styling via explicit `button-accent` class instead of brittle `[href=...]` selectors
- Decorative emoji hidden from screen readers (`aria-hidden`)
- Stale comments fixed (landing.js scoring note, nixpacks SDK version), `.gitignore` anchoring, EF/Pomelo version pin documented

### Deliberately declined
- **Unique index on `Users.GoogleId`**: `GoogleId` is informational only — users are keyed by the unique `Email` index, and sign-ins without a `NameIdentifier` claim store `""`, which would collide under a unique index.

### Follow-up (not in this PR)
- Restrict `AllowedHosts` via Railway env var (currently `*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database-assigned IDs for custom subjects (prevents ID collisions)
  * Improved grade-trend visualization on the home page

* **Bug Fixes**
  * Case-insensitive route matching
  * Stronger auth/session handling with proper error redirects

* **Improvements**
  * Ownership and input validation for creating/editing/deleting tests
  * Accessibility and stylesheet updates (button accents, conditional smooth scroll)
  * Added dedicated 404 page

* **Chores**
  * Updated tooling/config and environment examples; bumped packages and config versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->