### PR TITLE
style: bring repo in line with pinned CSharpier 1.3.0

### DIFF
--- a/WSIST/.csharpierignore
+++ b/WSIST/.csharpierignore
@@ -1,0 +1,4 @@
+# EF Core generates these files; they are not hand-edited, so leave their
+# formatting to the tool that emits them rather than churning them through
+# CSharpier on every run.
+**/Migrations/*.cs

--- a/WSIST/WSIST.Engine/PriorityCalculator.cs
+++ b/WSIST/WSIST.Engine/PriorityCalculator.cs
@@ -73,7 +73,11 @@ public class PriorityCalculator
         return sum;
     }
 
-    public List<Test> GetStudyRecommendations(List<Test> allTests, double hoursAvailable, DateOnly? asOfDate = null)
+    public List<Test> GetStudyRecommendations(
+        List<Test> allTests,
+        double hoursAvailable,
+        DateOnly? asOfDate = null
+    )
     {
         var reference = asOfDate ?? DateOnly.FromDateTime(DateTime.Today);
         var topCount = hoursAvailable switch
@@ -97,7 +101,8 @@ public class PriorityCalculator
     // it has consistently high priority throughout the week and deserves repeated attention.
     public Dictionary<DateOnly, List<Test>> GetWeeklyPlan(
         List<Test> allTests,
-        Dictionary<DayOfWeek, double> hoursPerDay)
+        Dictionary<DayOfWeek, double> hoursPerDay
+    )
     {
         var plan = new Dictionary<DateOnly, List<Test>>();
         var today = DateOnly.FromDateTime(DateTime.Today);
@@ -107,9 +112,7 @@ public class PriorityCalculator
             var date = today.AddDays(i);
             var hours = hoursPerDay.GetValueOrDefault(date.DayOfWeek, 0);
 
-            plan[date] = hours > 0
-                ? GetStudyRecommendations(allTests, hours, date)
-                : [];
+            plan[date] = hours > 0 ? GetStudyRecommendations(allTests, hours, date) : [];
         }
 
         return plan;

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -9,10 +9,18 @@ public class TestManagement
         this.context = context;
     }
 
-    public List<Test> LoadAllTests(int userId) => context.Tests.Where(t => t.UserId == userId).ToList();
+    public List<Test> LoadAllTests(int userId) =>
+        context.Tests.Where(t => t.UserId == userId).ToList();
 
-    public void NewTestMaker(string title, int subjectId, DateOnly dueDate,
-        Test.TestVolume volume, Test.PersonalUnderstanding understanding, double? grade, int userId)
+    public void NewTestMaker(
+        string title,
+        int subjectId,
+        DateOnly dueDate,
+        Test.TestVolume volume,
+        Test.PersonalUnderstanding understanding,
+        double? grade,
+        int userId
+    )
     {
         if (string.IsNullOrWhiteSpace(title))
             throw new ArgumentException("Title cannot be empty.", nameof(title));
@@ -27,14 +35,22 @@ public class TestManagement
             Volume = volume,
             Understanding = understanding,
             Grade = TestAssistants.GradeVerifier(dueDate, grade),
-            UserId = userId
+            UserId = userId,
         };
         context.Tests.Add(test);
         context.SaveChanges();
     }
 
-    public void TestEditor(Guid id, string title, int subjectId, DateOnly dueDate,
-        Test.TestVolume volume, Test.PersonalUnderstanding understanding, double? grade, int userId)
+    public void TestEditor(
+        Guid id,
+        string title,
+        int subjectId,
+        DateOnly dueDate,
+        Test.TestVolume volume,
+        Test.PersonalUnderstanding understanding,
+        double? grade,
+        int userId
+    )
     {
         if (string.IsNullOrWhiteSpace(title))
             throw new ArgumentException("Title cannot be empty.", nameof(title));
@@ -42,7 +58,8 @@ public class TestManagement
 
         var test = context.Tests.Find(id);
         // Only the owner may edit a test.
-        if (test is null || test.UserId != userId) return;
+        if (test is null || test.UserId != userId)
+            return;
 
         test.Title = title;
         test.Subject = subjectId;
@@ -57,24 +74,30 @@ public class TestManagement
     {
         var test = context.Tests.Find(id);
         // Only the owner may delete a test.
-        if (test is null || test.UserId != userId) return;
+        if (test is null || test.UserId != userId)
+            return;
         context.Tests.Remove(test);
         context.SaveChanges();
     }
+
     private void EnsureSubjectAccessible(int subjectId, int userId)
     {
         // A test may only reference a system subject or one of the user's own
         // custom subjects — never another user's subject.
-        var accessible = context.Subjects
-            .Any(s => s.Id == subjectId && (s.IsSystem || s.UserId == userId));
+        var accessible = context.Subjects.Any(s =>
+            s.Id == subjectId && (s.IsSystem || s.UserId == userId)
+        );
         if (!accessible)
-            throw new ArgumentException("Subject does not exist or is not accessible.", nameof(subjectId));
+            throw new ArgumentException(
+                "Subject does not exist or is not accessible.",
+                nameof(subjectId)
+            );
     }
 
     public List<Subject> GetSubjectsForUser(int userId)
     {
-        return context.Subjects
-            .Where(s => s.IsSystem || s.UserId == userId)
+        return context
+            .Subjects.Where(s => s.IsSystem || s.UserId == userId)
             .OrderBy(s => s.IsSystem ? 0 : 1)
             .ThenBy(s => s.Name)
             .ToList();
@@ -90,7 +113,7 @@ public class TestManagement
         {
             Name = name,
             IsSystem = false,
-            UserId = userId
+            UserId = userId,
         };
         context.Subjects.Add(subject);
         context.SaveChanges();
@@ -98,11 +121,14 @@ public class TestManagement
 
     public bool RemoveCustomSubject(int subjectId, int userId)
     {
-        var subject = context.Subjects
-            .FirstOrDefault(s => s.Id == subjectId && s.UserId == userId && !s.IsSystem);
-        if (subject is null) return false;
+        var subject = context.Subjects.FirstOrDefault(s =>
+            s.Id == subjectId && s.UserId == userId && !s.IsSystem
+        );
+        if (subject is null)
+            return false;
         // The Tests.Subject FK is Restrict — deleting a subject still in use would throw.
-        if (context.Tests.Any(t => t.Subject == subjectId)) return false;
+        if (context.Tests.Any(t => t.Subject == subjectId))
+            return false;
         context.Subjects.Remove(subject);
         context.SaveChanges();
         return true;
@@ -120,7 +146,8 @@ public class TestManagement
             throw new ArgumentException("Display name cannot be empty.", nameof(displayName));
 
         var user = context.Users.Find(userId);
-        if (user is null) return;
+        if (user is null)
+            return;
         user.DisplayName = trimmed;
         context.SaveChanges();
     }
@@ -131,7 +158,8 @@ public class TestManagement
             throw new ArgumentException("Email cannot be empty.", nameof(email));
 
         var user = context.Users.FirstOrDefault(u => u.Email == email);
-        if (user is not null) return user;
+        if (user is not null)
+            return user;
 
         try
         {
@@ -140,7 +168,7 @@ public class TestManagement
                 Email = email,
                 DisplayName = displayName,
                 GoogleId = googleId,
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = DateTime.UtcNow,
             };
             context.Users.Add(user);
             context.SaveChanges();
@@ -153,7 +181,8 @@ public class TestManagement
             // If no row exists, the failure had another cause; surface it.
             context.ChangeTracker.Clear();
             var existing = context.Users.FirstOrDefault(u => u.Email == email);
-            if (existing is null) throw;
+            if (existing is null)
+                throw;
             return existing;
         }
     }
@@ -161,21 +190,25 @@ public class TestManagement
     public void DeleteUser(int userId)
     {
         var user = context.Users.Find(userId);
-        if (user is null) return;
+        if (user is null)
+            return;
         context.Users.Remove(user);
         context.SaveChanges();
     }
 
-    public record SubjectGradeAverage(int SubjectId, string SubjectName, double AverageGrade, int GradedTestCount);
+    public record SubjectGradeAverage(
+        int SubjectId,
+        string SubjectName,
+        double AverageGrade,
+        int GradedTestCount
+    );
 
     public List<SubjectGradeAverage> GetGradeAverages(int userId)
     {
-        var subjects = context.Subjects
-            .Where(s => s.IsSystem || s.UserId == userId)
-            .ToList();
+        var subjects = context.Subjects.Where(s => s.IsSystem || s.UserId == userId).ToList();
 
-        return context.Tests
-            .Where(t => t.UserId == userId && t.Grade != null)
+        return context
+            .Tests.Where(t => t.UserId == userId && t.Grade != null)
             .AsEnumerable()
             .GroupBy(t => t.Subject)
             .Select(g =>

--- a/WSIST/WSIST.Engine/User.cs
+++ b/WSIST/WSIST.Engine/User.cs
@@ -6,6 +6,7 @@ public class User
     public string Email { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
     public string GoogleId { get; set; } = string.Empty;
+
     // Default so a User created without an explicit timestamp never persists
     // DateTime.MinValue (0001-01-01).
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/WSIST/WSIST.Engine/WsistContext.cs
+++ b/WSIST/WSIST.Engine/WsistContext.cs
@@ -4,7 +4,8 @@ namespace WSIST.Engine;
 
 public class WsistContext : DbContext
 {
-    public WsistContext(DbContextOptions<WsistContext> options) : base(options) { }
+    public WsistContext(DbContextOptions<WsistContext> options)
+        : base(options) { }
 
     public DbSet<Test> Tests { get; set; }
     public DbSet<User> Users { get; set; }
@@ -22,12 +23,14 @@ public class WsistContext : DbContext
             entity.Property(e => e.Understanding).HasConversion<int>();
             entity.Property(e => e.Grade).IsRequired(false);
 
-            entity.HasOne(t => t.User)
+            entity
+                .HasOne(t => t.User)
                 .WithMany(u => u.Tests)
                 .HasForeignKey(t => t.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            entity.HasOne<Subject>()
+            entity
+                .HasOne<Subject>()
                 .WithMany()
                 .HasForeignKey(t => t.Subject)
                 .OnDelete(DeleteBehavior.Restrict);
@@ -44,19 +47,50 @@ public class WsistContext : DbContext
             entity.Property(e => e.Name).HasMaxLength(100).IsRequired();
             entity.Property(e => e.IsSystem).HasDefaultValue(false);
 
-            entity.HasOne(s => s.User)
+            entity
+                .HasOne(s => s.User)
                 .WithMany()
                 .HasForeignKey(s => s.UserId)
                 .IsRequired(false)
                 .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasData(
-                new Subject { Id = -6, Name = "Math", IsSystem = true },
-                new Subject { Id = -5, Name = "English", IsSystem = true },
-                new Subject { Id = -4, Name = "French", IsSystem = true },
-                new Subject { Id = -3, Name = "German", IsSystem = true },
-                new Subject { Id = -2, Name = "Chemistry", IsSystem = true },
-                new Subject { Id = -1, Name = "Other", IsSystem = true }
+                new Subject
+                {
+                    Id = -6,
+                    Name = "Math",
+                    IsSystem = true,
+                },
+                new Subject
+                {
+                    Id = -5,
+                    Name = "English",
+                    IsSystem = true,
+                },
+                new Subject
+                {
+                    Id = -4,
+                    Name = "French",
+                    IsSystem = true,
+                },
+                new Subject
+                {
+                    Id = -3,
+                    Name = "German",
+                    IsSystem = true,
+                },
+                new Subject
+                {
+                    Id = -2,
+                    Name = "Chemistry",
+                    IsSystem = true,
+                },
+                new Subject
+                {
+                    Id = -1,
+                    Name = "Other",
+                    IsSystem = true,
+                }
             );
         });
 

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -366,15 +366,17 @@ public class UnitTests
         var manager = new TestManagement(context);
 
         //act + assert
-        Assert.Throws<ArgumentException>(() => manager.NewTestMaker(
-            "   ",
-            0,
-            new DateOnly(2026, 12, 01),
-            Test.TestVolume.Medium,
-            Test.PersonalUnderstanding.Medium,
-            null,
-            user.Id
-        ));
+        Assert.Throws<ArgumentException>(() =>
+            manager.NewTestMaker(
+                "   ",
+                0,
+                new DateOnly(2026, 12, 01),
+                Test.TestVolume.Medium,
+                Test.PersonalUnderstanding.Medium,
+                null,
+                user.Id
+            )
+        );
     }
 
     [Test]
@@ -398,15 +400,17 @@ public class UnitTests
         var subjectId = manager.GetSubjectsForUser(owner.Id).First(s => !s.IsSystem).Id;
 
         //act + assert — attacker may not file tests under the owner's subject
-        Assert.Throws<ArgumentException>(() => manager.NewTestMaker(
-            "Sneaky Test",
-            subjectId,
-            new DateOnly(2026, 12, 01),
-            Test.TestVolume.Medium,
-            Test.PersonalUnderstanding.Medium,
-            null,
-            attacker.Id
-        ));
+        Assert.Throws<ArgumentException>(() =>
+            manager.NewTestMaker(
+                "Sneaky Test",
+                subjectId,
+                new DateOnly(2026, 12, 01),
+                Test.TestVolume.Medium,
+                Test.PersonalUnderstanding.Medium,
+                null,
+                attacker.Id
+            )
+        );
     }
 
     [Test]

--- a/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
+++ b/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
@@ -8,7 +8,8 @@ namespace WSIST.Web.Components.Pages;
 public abstract class AuthenticatedComponentBase(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
-    NavigationManager navigation) : ComponentBase
+    NavigationManager navigation
+) : ComponentBase
 {
     protected int CurrentUserId { get; private set; }
 
@@ -54,10 +55,11 @@ public abstract class AuthenticatedComponentBase(
     protected virtual Task OnAuthenticatedAsync() => Task.CompletedTask;
 
     // Shared grade-to-CSS mapping used by the dashboard and study pages.
-    protected static string GetGradeClass(double avg) => avg switch
-    {
-        >= 5 => "grade-good",
-        >= 4 => "grade-ok",
-        _ => "grade-poor"
-    };
+    protected static string GetGradeClass(double avg) =>
+        avg switch
+        {
+            >= 5 => "grade-good",
+            >= 4 => "grade-ok",
+            _ => "grade-poor",
+        };
 }

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -8,8 +8,8 @@ public partial class Home(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
     NavigationManager navigation,
-    PriorityCalculator calculator)
-    : AuthenticatedComponentBase(management, authStateProvider, navigation)
+    PriorityCalculator calculator
+) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private List<Test> allTests = [];
     private List<Test> tests = [];
@@ -47,10 +47,7 @@ public partial class Home(
         return allTests
             .Where(t => t.Grade.HasValue)
             .GroupBy(t => t.Subject)
-            .ToDictionary(
-                g => g.Key,
-                g => g.Average(t => t.Grade!.Value)
-            );
+            .ToDictionary(g => g.Key, g => g.Average(t => t.Grade!.Value));
     }
 
     // Chronological grade history per subject, only for subjects with 2+ graded tests.
@@ -62,9 +59,7 @@ public partial class Home(
             .Where(g => g.Count() >= 2)
             .ToDictionary(
                 g => g.Key,
-                g => g.OrderBy(t => t.DueDate)
-                      .Select(t => (t.DueDate, t.Grade!.Value))
-                      .ToList()
+                g => g.OrderBy(t => t.DueDate).Select(t => (t.DueDate, t.Grade!.Value)).ToList()
             );
     }
 
@@ -158,9 +153,7 @@ public partial class Home(
     private void Refresh()
     {
         allTests = management.LoadAllTests(CurrentUserId);
-        tests = (showPastTests
-                ? allTests
-                : allTests.Where(t => t.DueDate >= Today))
+        tests = (showPastTests ? allTests : allTests.Where(t => t.DueDate >= Today))
             .OrderBy(t => t.DueDate)
             .ToList();
         topRecommendation = calculator.GetStudyRecommendations(allTests, 2).FirstOrDefault();

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor.cs
@@ -7,8 +7,8 @@ namespace WSIST.Web.Components.Pages;
 public partial class Settings(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
-    NavigationManager navigation)
-    : AuthenticatedComponentBase(management, authStateProvider, navigation)
+    NavigationManager navigation
+) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private User? currentUser;
     private List<Subject> subjects = [];
@@ -31,7 +31,8 @@ public partial class Settings(
 
     private void SaveDisplayName()
     {
-        if (string.IsNullOrWhiteSpace(editedDisplayName)) return;
+        if (string.IsNullOrWhiteSpace(editedDisplayName))
+            return;
         management.UpdateDisplayName(CurrentUserId, editedDisplayName);
         currentUser = management.GetUser(CurrentUserId);
         saveMessage = "Saved.";
@@ -66,7 +67,8 @@ public partial class Settings(
         subjectError = null;
         if (!management.RemoveCustomSubject(subjectId, CurrentUserId))
         {
-            subjectError = "Cannot delete a subject that still has tests. Delete or reassign those tests first.";
+            subjectError =
+                "Cannot delete a subject that still has tests. Delete or reassign those tests first.";
             StateHasChanged();
             return;
         }
@@ -75,6 +77,7 @@ public partial class Settings(
     }
 
     private void ShowDeleteConfirm() => showDeleteConfirm = true;
+
     private void CancelDelete() => showDeleteConfirm = false;
 
     private void ConfirmDeleteAccount()

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -5,8 +5,12 @@ using WSIST.Engine;
 
 namespace WSIST.Web.Components.Pages;
 
-public partial class Study(TestManagement management, AuthenticationStateProvider authStateProvider, NavigationManager navigation, PriorityCalculator calculator)
-    : AuthenticatedComponentBase(management, authStateProvider, navigation)
+public partial class Study(
+    TestManagement management,
+    AuthenticationStateProvider authStateProvider,
+    NavigationManager navigation,
+    PriorityCalculator calculator
+) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private List<Test> allTests = [];
     private List<Test> recommendations = [];
@@ -18,13 +22,13 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
     private bool weeklyMode = false;
     private Dictionary<DayOfWeek, double> weeklyHours = new()
     {
-        { DayOfWeek.Monday,    1 },
-        { DayOfWeek.Tuesday,   1 },
+        { DayOfWeek.Monday, 1 },
+        { DayOfWeek.Tuesday, 1 },
         { DayOfWeek.Wednesday, 1 },
-        { DayOfWeek.Thursday,  1 },
-        { DayOfWeek.Friday,    1 },
-        { DayOfWeek.Saturday,  0 },
-        { DayOfWeek.Sunday,    0 },
+        { DayOfWeek.Thursday, 1 },
+        { DayOfWeek.Friday, 1 },
+        { DayOfWeek.Saturday, 0 },
+        { DayOfWeek.Sunday, 0 },
     };
     private Dictionary<DateOnly, List<Test>> weeklyPlan = [];
     private bool weeklyCalculated = false;
@@ -105,7 +109,8 @@ public partial class Study(TestManagement management, AuthenticationStateProvide
             .DefaultIfEmpty(0)
             .Average();
 
-        var subjectName = subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? test.Subject.ToString();
+        var subjectName =
+            subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? test.Subject.ToString();
 
         var parts = new List<string>
         {

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
@@ -17,12 +17,15 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownProxies.Clear();
 });
 
-var connStr = builder.Configuration.GetConnectionString("DatabaseConnection")
+var connStr =
+    builder.Configuration.GetConnectionString("DatabaseConnection")
     ?? throw new InvalidOperationException("DatabaseConnection string is missing.");
 builder.Services.AddDbContext<WsistContext>(options =>
-    options.UseMySql(connStr, ServerVersion.AutoDetect(connStr)));
+    options.UseMySql(connStr, ServerVersion.AutoDetect(connStr))
+);
 
-builder.Services.AddAuthentication(options =>
+builder
+    .Services.AddAuthentication(options =>
     {
         options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
         options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
@@ -36,9 +39,11 @@ builder.Services.AddAuthentication(options =>
     })
     .AddGoogle(options =>
     {
-        options.ClientId = builder.Configuration["Google:ClientId"]
+        options.ClientId =
+            builder.Configuration["Google:ClientId"]
             ?? throw new InvalidOperationException("Google:ClientId is missing");
-        options.ClientSecret = builder.Configuration["Google:ClientSecret"]
+        options.ClientSecret =
+            builder.Configuration["Google:ClientSecret"]
             ?? throw new InvalidOperationException("Google:ClientSecret is missing");
     });
 
@@ -54,60 +59,75 @@ if (!app.Environment.IsDevelopment())
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
     app.UseHsts();
 }
-app.UseForwardedHeaders();  
+app.UseForwardedHeaders();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseAntiforgery();
 
-app.Use(async (context, next) =>
-{
-    var isAuthenticated = context.User?.Identity?.IsAuthenticated ?? false;
-    var protectedPaths = new[] { "/", "/study", "/settings" };
-    if (protectedPaths.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase) && !isAuthenticated)
+app.Use(
+    async (context, next) =>
     {
-        context.Response.Redirect("/login-page");
-        return;
+        var isAuthenticated = context.User?.Identity?.IsAuthenticated ?? false;
+        var protectedPaths = new[] { "/", "/study", "/settings" };
+        if (
+            protectedPaths.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase)
+            && !isAuthenticated
+        )
+        {
+            context.Response.Redirect("/login-page");
+            return;
+        }
+        await next();
     }
-    await next();
-});
+);
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 
-app.MapGet("/login", () => Results.Challenge(
-    new AuthenticationProperties { RedirectUri = "/" },
-    [GoogleDefaults.AuthenticationScheme]));
+app.MapGet(
+    "/login",
+    () =>
+        Results.Challenge(
+            new AuthenticationProperties { RedirectUri = "/" },
+            [GoogleDefaults.AuthenticationScheme]
+        )
+);
 
-app.MapGet("/logout", async (HttpContext ctx) =>
-{
-    await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    return Results.Redirect("/login-page");
-}).AllowAnonymous();
+app.MapGet(
+        "/logout",
+        async (HttpContext ctx) =>
+        {
+            await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return Results.Redirect("/login-page");
+        }
+    )
+    .AllowAnonymous();
 
-app.MapGet("/api/grades", async (HttpContext ctx, TestManagement management) =>
-{
-    if (!ctx.User.Identity?.IsAuthenticated ?? true)
-        return Results.Unauthorized();
+app.MapGet(
+        "/api/grades",
+        async (HttpContext ctx, TestManagement management) =>
+        {
+            if (!ctx.User.Identity?.IsAuthenticated ?? true)
+                return Results.Unauthorized();
 
-    var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
-    if (email is null) return Results.Unauthorized();
+            var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
+            if (email is null)
+                return Results.Unauthorized();
 
-    // Users are keyed by their (unique) email; GoogleId is informational
-    // only, so a missing NameIdentifier claim simply stores an empty value.
-    var user = management.GetOrCreateUser(
-        email,
-        ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",
-        ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ""
-    );
+            // Users are keyed by their (unique) email; GoogleId is informational
+            // only, so a missing NameIdentifier claim simply stores an empty value.
+            var user = management.GetOrCreateUser(
+                email,
+                ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",
+                ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ""
+            );
 
-    var averages = management.GetGradeAverages(user.Id);
+            var averages = management.GetGradeAverages(user.Id);
 
-    return Results.Ok(new
-    {
-        userId = user.Id,
-        subjects = averages
-    });
-}).RequireAuthorization();
+            return Results.Ok(new { userId = user.Id, subjects = averages });
+        }
+    )
+    .RequireAuthorization();
 
 using (var scope = app.Services.CreateScope())
 {


### PR DESCRIPTION
## What

The tool manifest pins **CSharpier 1.3.0**, but the tree was never reformatted with that version, so `dotnet csharpier check .` currently fails on 10 hand-written files (old constructor / spacing style). This blocks the "CSharpier passes clean" gate required for every PR in the polish feature batch.

This PR:
- Reformats the 10 hand-written files to CSharpier 1.3.0 style.
- Adds `WSIST/.csharpierignore` excluding the generated EF Core migrations (`**/Migrations/*.cs`) so the format gate stays green without churning generated code.

## Why

Pure infrastructure/baseline change so subsequent feature branches start from a CSharpier-clean tree and their diffs stay focused.

## Verification

- `dotnet csharpier check .` → clean
- `dotnet build` → succeeds
- `dotnet test` → 16/16 pass

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and organization across the application for better maintainability.

* **Chores**
  * Updated configuration files and project structure for consistency.
  * Refined authentication and middleware handling in the startup process.

---

**Note:** This release consists primarily of internal code improvements with no new user-facing features or changes to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->