### PR TITLE
fix: invert date picker icon for dark theme visibility

### DIFF
--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -173,6 +173,15 @@ main {
     padding-right: 36px;
 }
 
+/* Date picker icon — the native indicator is dark by default and nearly
+   invisible against the dark amber theme, so invert it to a light glyph.
+   WebKit/Blink only (Chrome, Edge, Safari); Firefox renders its own calendar
+   icon and ignores this pseudo-element, so this is a no-op there, not a break. */
+input[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+    cursor: pointer;
+}
+
 /* Form layout within modal */
 .form-group {
     margin-bottom: 18px;


### PR DESCRIPTION
## Problem

The native `<input type="date">` calendar-picker indicator renders dark by default and is nearly invisible against WSIST's dark amber theme (the Add/Edit Test modal's *Due date* field).

## Fix

```css
input[type="date"]::-webkit-calendar-picker-indicator {
    filter: invert(1);
    cursor: pointer;
}
```

Inverts the glyph to light so it reads clearly on the dark background, and adds a pointer cursor.

## Browser scope

This pseudo-element is **WebKit/Blink-specific** (Chrome, Edge, Safari). **Firefox** renders its own calendar icon and ignores `::-webkit-calendar-picker-indicator` entirely — so this rule is a no-op there, not a regression. Firefox's default icon already has acceptable contrast, so no separate Firefox rule is needed.

## Verification

- `dotnet csharpier check .` → clean (CSS-only change)
- `dotnet test` → 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced date input field icon visibility for improved readability on dark-themed backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->