### PR TITLE
feat: add self-service data export (CSV/JSON)

### DIFF
--- a/WSIST/WSIST.Engine/TestExporter.cs
+++ b/WSIST/WSIST.Engine/TestExporter.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using System.Text;
+
+namespace WSIST.Engine;
+
+/// <summary>
+/// One row of a user's data export. Holds typed values so JSON keeps real
+/// types (ISO date, numeric grade) while CSV formats them itself.
+/// </summary>
+public record TestExportRow(
+    string Title,
+    string Subject,
+    DateOnly DueDate,
+    string Volume,
+    string Understanding,
+    double? Grade
+);
+
+public static class TestExporter
+{
+    private static readonly string[] Header =
+    [
+        "Title",
+        "Subject",
+        "DueDate",
+        "Volume",
+        "Understanding",
+        "Grade",
+    ];
+
+    /// <summary>
+    /// Serialises export rows to RFC 4180 CSV (CRLF line endings, quoted
+    /// fields where needed) with formula-injection mitigation on the free-text
+    /// columns.
+    /// </summary>
+    public static string ToCsv(IReadOnlyList<TestExportRow> rows)
+    {
+        var sb = new StringBuilder();
+        sb.Append(string.Join(',', Header.Select(Field))).Append("\r\n");
+
+        foreach (var r in rows)
+        {
+            sb.Append(Field(r.Title))
+                .Append(',')
+                .Append(Field(r.Subject))
+                .Append(',')
+                .Append(r.DueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))
+                .Append(',')
+                .Append(Field(r.Volume))
+                .Append(',')
+                .Append(Field(r.Understanding))
+                .Append(',')
+                .Append(r.Grade?.ToString(CultureInfo.InvariantCulture) ?? "")
+                .Append("\r\n");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Field(string value)
+    {
+        var v = value ?? "";
+
+        // Formula-injection mitigation: a cell beginning with =, +, -, @, or a
+        // control character can be executed by spreadsheet apps. Prefix with a
+        // single quote so it is treated as literal text. Titles and custom
+        // subject names are user-controlled, so this matters.
+        if (v.Length > 0 && v[0] is '=' or '+' or '-' or '@' or '\t' or '\r')
+            v = "'" + v;
+
+        // RFC 4180: quote fields containing the delimiter, a quote, or a newline,
+        // doubling any embedded quotes.
+        if (v.Contains('"') || v.Contains(',') || v.Contains('\n') || v.Contains('\r'))
+            v = "\"" + v.Replace("\"", "\"\"") + "\"";
+
+        return v;
+    }
+}

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -257,4 +257,32 @@ public class TestManagement
             .OrderBy(x => x.SubjectName)
             .ToList();
     }
+
+    /// <summary>
+    /// Every test belonging to the user — past and future, graded or not —
+    /// shaped for a data-portability export with subject names resolved and
+    /// enum values rendered to readable text. Strictly scoped to
+    /// <paramref name="userId"/>: another user's rows can never appear.
+    /// </summary>
+    public List<TestExportRow> GetTestExport(int userId)
+    {
+        var subjects = context
+            .Subjects.Where(s => s.IsSystem || s.UserId == userId)
+            .ToDictionary(s => s.Id, s => s.Name);
+
+        return context
+            .Tests.Where(t => t.UserId == userId)
+            .AsEnumerable()
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Title)
+            .Select(t => new TestExportRow(
+                t.Title,
+                subjects.TryGetValue(t.Subject, out var name) ? name : t.Subject.ToString(),
+                t.DueDate,
+                Test.VolumeHelper(t.Volume),
+                Test.UnderstandingHelper(t.Understanding),
+                t.Grade
+            ))
+            .ToList();
+    }
 }

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -540,4 +540,119 @@ public class UnitTests
         //assert
         Assert.That(created.UserId, Is.EqualTo(otherUser.Id));
     }
+
+    [Test]
+    public void GetTestExport_OnlyIncludesRequestingUsersTests()
+    {
+        //arrange
+        using var context = CreateContext();
+        var owner = SeedUser(context);
+        var other = new User
+        {
+            Email = "other@example.com",
+            DisplayName = "Other",
+            GoogleId = "google-456",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(other);
+        context.SaveChanges();
+        var subjectId = SeedSystemSubject(context);
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Owner Test",
+            subjectId,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            owner.Id
+        );
+        manager.NewTestMaker(
+            "Other Test",
+            subjectId,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            other.Id
+        );
+
+        //act
+        var export = manager.GetTestExport(owner.Id);
+
+        //assert — the export is strictly scoped to the requesting user
+        Assert.That(export.Any(r => r.Title == "Owner Test"));
+        Assert.That(export.Any(r => r.Title == "Other Test"), Is.False);
+    }
+
+    [Test]
+    public void GetTestExport_IncludesPastGradedTestsWithResolvedSubjectName()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var subjectId = SeedSystemSubject(context, "Math");
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Past Exam",
+            subjectId,
+            new DateOnly(2025, 01, 01),
+            Test.TestVolume.High,
+            Test.PersonalUnderstanding.Low,
+            5.5,
+            user.Id
+        );
+
+        //act
+        var export = manager.GetTestExport(user.Id);
+
+        //assert
+        var row = export.Single(r => r.Title == "Past Exam");
+        Assert.That(row.Subject, Is.EqualTo("Math"));
+        Assert.That(row.Grade, Is.EqualTo(5.5));
+        Assert.That(row.Volume, Is.EqualTo("High"));
+    }
+
+    [Test]
+    public void ToCsv_WritesHeaderAndFormatsValues()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("Exam", "Math", new DateOnly(2026, 03, 01), "High", "Low", 5.5),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        Assert.That(csv, Does.StartWith("Title,Subject,DueDate,Volume,Understanding,Grade"));
+        Assert.That(csv, Does.Contain("2026-03-01"));
+        Assert.That(csv, Does.Contain("5.5"));
+    }
+
+    [Test]
+    public void ToCsv_EscapesDelimitersAndQuotes()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("Title, comma", "Sub \"quote\"", new DateOnly(2026, 03, 01), "High", "Low", null),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        Assert.That(csv, Does.Contain("\"Title, comma\""));
+        Assert.That(csv, Does.Contain("\"Sub \"\"quote\"\"\""));
+    }
+
+    [Test]
+    public void ToCsv_MitigatesFormulaInjection()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("=SUM(A1:A2)", "Math", new DateOnly(2026, 03, 01), "High", "Low", null),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        //a leading '=' must be neutralised so spreadsheets treat it as text
+        Assert.That(csv, Does.Contain("'=SUM(A1:A2)"));
+    }
 }

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor
@@ -79,6 +79,24 @@
             </div>
 
             <div class="settings-block">
+                <p class="settings-block-label">Data</p>
+                <div class="settings-card">
+                    <div class="settings-row settings-row-last">
+                        <div>
+                            <span class="settings-row-key">Export my data</span>
+                            <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
+                                Download all your tests and grades, including past graded ones.
+                            </p>
+                        </div>
+                        <div class="settings-inline">
+                            <a href="/api/export?format=csv" class="button-primary button-accent" data-enhance-nav="false" download>CSV</a>
+                            <a href="/api/export?format=json" class="button-primary" data-enhance-nav="false" download>JSON</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="settings-block">
                 <p class="settings-block-label">Account</p>
                 <div class="settings-card">
                     @if (!showDeleteConfirm)

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
@@ -125,6 +127,54 @@ app.MapGet(
             var averages = management.GetGradeAverages(user.Id);
 
             return Results.Ok(new { userId = user.Id, subjects = averages });
+        }
+    )
+    .RequireAuthorization();
+
+app.MapGet(
+        "/api/export",
+        (HttpContext ctx, TestManagement management, string? format) =>
+        {
+            if (!ctx.User.Identity?.IsAuthenticated ?? true)
+                return Results.Unauthorized();
+
+            var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
+            if (email is null)
+                return Results.Unauthorized();
+
+            // Resolve the user from their own authenticated claims and scope the
+            // export strictly to that id. The caller cannot supply a user id, so
+            // one user's export can never contain another user's rows. This
+            // endpoint exists for nDSG / GDPR data portability.
+            var user = management.GetOrCreateUser(
+                email,
+                ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",
+                ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ""
+            );
+
+            var rows = management.GetTestExport(user.Id);
+
+            if (string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+            {
+                var json = JsonSerializer.Serialize(
+                    rows,
+                    new JsonSerializerOptions { WriteIndented = true }
+                );
+                return Results.File(
+                    Encoding.UTF8.GetBytes(json),
+                    "application/json",
+                    "wsist-tests.json"
+                );
+            }
+
+            // Default to CSV. Prepend a UTF-8 BOM so spreadsheet apps (Excel)
+            // render accented characters — relevant for German subject names.
+            var csv = TestExporter.ToCsv(rows);
+            var csvBytes = Encoding
+                .UTF8.GetPreamble()
+                .Concat(Encoding.UTF8.GetBytes(csv))
+                .ToArray();
+            return Results.File(csvBytes, "text/csv", "wsist-tests.csv");
         }
     )
     .RequireAuthorization();


### PR DESCRIPTION
## Goal

Let a user download their own tests and grades from Settings — **nDSG / GDPR data portability**.

## Approach

- **`GET /api/export?format=csv|json`** — a minimal API endpoint (mirrors the existing `/api/grades`), `RequireAuthorization()` + explicit auth checks. CSV is the default; JSON is the optional second format.
- The endpoint resolves the user from **their own authenticated claims** and queries `GetTestExport(user.Id)`. The caller cannot pass a user id, so **one user's export can never contain another user's rows**.
- A plain HTTP endpoint (triggered by a link in Settings) is used deliberately — not a file stream over the Blazor SignalR circuit.
- Settings gains a **"Data"** block with CSV / JSON download links.

## Security (this endpoint handles personal data)

- **User isolation**: scoping is by the authenticated user's id only; covered by a deliberate test (`GetTestExport_OnlyIncludesRequestingUsersTests`).
- **CSV formula injection**: free-text columns (Title, custom Subject names) with a leading `= + - @` or control char are prefixed with `'` so spreadsheets treat them as text.
- **CSV escaping**: RFC 4180 quoting of delimiters/quotes/newlines.
- Read-only `GET` returning the user's own data to their own browser — cross-origin reads are blocked by CORS, so there's no CSRF data-leak vector (same posture as `/api/grades`).

## Output details

- CSV columns: `Title, Subject, DueDate (ISO), Volume, Understanding, Grade`, including **past graded** tests.
- CSV carries a UTF-8 BOM so Excel renders accented characters (German subject names).
- JSON: indented array of the same typed rows (ISO date, numeric grade).

## Verification

- `dotnet csharpier check .` → clean
- `dotnet build` → succeeds
- `dotnet test` → 27/27 pass (5 new: user isolation, past-graded inclusion + subject-name resolution, CSV header/format, escaping, injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now export their test data in CSV or JSON format from the Settings page
  * Export includes test information such as titles, subjects, due dates, volumes, understanding levels, and grades

<!-- end of auto-generated comment: release notes by coderabbit.ai -->