### PR TITLE
fix: reorder subject index migration to be MySQL FK-safe (production hotfix)

### DIFF
--- a/WSIST/WSIST.Engine/Migrations/20260616205925_AddSubjectNameUniqueIndex.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260616205925_AddSubjectNameUniqueIndex.cs
@@ -10,10 +10,11 @@ namespace WSIST.Engine.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Subjects_UserId",
-                table: "Subjects");
-
+            // Order matters on MySQL: IX_Subjects_UserId backs the
+            // FK_Subjects_Users_UserId constraint and cannot be dropped while it
+            // is the only index serving that FK. Alter the collation first, then
+            // create the composite (UserId, Name) index — whose leading UserId
+            // column can serve the FK — and only then drop the old index.
             migrationBuilder.AlterColumn<string>(
                 name: "Name",
                 table: "Subjects",
@@ -32,14 +33,22 @@ namespace WSIST.Engine.Migrations
                 table: "Subjects",
                 columns: new[] { "UserId", "Name" },
                 unique: true);
+
+            migrationBuilder.DropIndex(name: "IX_Subjects_UserId", table: "Subjects");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Subjects_UserId_Name",
-                table: "Subjects");
+            // Reverse in FK-safe order: recreate the single-column index so it
+            // can back the FK, then drop the composite index, then revert the
+            // collation.
+            migrationBuilder.CreateIndex(
+                name: "IX_Subjects_UserId",
+                table: "Subjects",
+                column: "UserId");
+
+            migrationBuilder.DropIndex(name: "IX_Subjects_UserId_Name", table: "Subjects");
 
             migrationBuilder.AlterColumn<string>(
                 name: "Name",
@@ -53,11 +62,6 @@ namespace WSIST.Engine.Migrations
                 oldCollation: "utf8mb4_general_ci")
                 .Annotation("MySql:CharSet", "utf8mb4")
                 .OldAnnotation("MySql:CharSet", "utf8mb4");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Subjects_UserId",
-                table: "Subjects",
-                column: "UserId");
         }
     }
 }


### PR DESCRIPTION
## Production hotfix

`db.Database.Migrate()` crashes at startup with:

```
MySqlException: Cannot drop index 'IX_Subjects_UserId': needed in a foreign key constraint
```

### Root cause
The `AddSubjectNameUniqueIndex` migration dropped `IX_Subjects_UserId` **before** creating its replacement. On MySQL that index is the sole backing for `FK_Subjects_Users_UserId`, so the `DROP INDEX` is rejected and the whole `Migrate()` call throws on boot.

CI didn't catch it because the test suite uses the in-memory provider, which ignores relational migrations.

### Fix
Reorder `Up()` so the FK always has a backing index at every step:
1. `AlterColumn` — set the `Name` collation (`utf8mb4_general_ci`)
2. `CreateIndex` — composite unique `IX_Subjects_UserId_Name` (leading `UserId` can serve the FK)
3. `DropIndex` — drop the old single-column `IX_Subjects_UserId`

`Down()` reverses in the mirror-safe order (recreate single-column index → drop composite → revert collation).

### Why this is safe to deploy
The original migration failed on its **first** statement (the drop), so nothing was applied and it was never recorded in `__EFMigrationsHistory`. The corrected migration runs from scratch on the next deploy and applies cleanly. No schema-shape change versus the original intent — only statement order differs.

### Testing
- `dotnet build -c Release` — green, 0 warnings.
- Statement order verified by hand against MySQL's FK-index-drop rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema optimization for improved subject data uniqueness management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->