### PR TITLE
feat: data export, in-app feedback, and EN/DE localization (polish batch)

### DIFF
--- a/WSIST/WSIST.Engine/Feedback.cs
+++ b/WSIST/WSIST.Engine/Feedback.cs
@@ -1,0 +1,29 @@
+namespace WSIST.Engine;
+
+public class Feedback
+{
+    public int Id { get; set; }
+    public int UserId { get; set; }
+    public User? User { get; set; }
+    public required string Message { get; set; }
+    public FeedbackCategory Category { get; set; }
+    public FeedbackStatus Status { get; set; } = FeedbackStatus.Open;
+
+    // Default so a Feedback created without an explicit timestamp never persists
+    // DateTime.MinValue (0001-01-01) — mirrors User.CreatedAt.
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public enum FeedbackCategory
+    {
+        Bug = 0,
+        Feature = 1,
+        Other = 2,
+    }
+
+    public enum FeedbackStatus
+    {
+        Open = 0,
+        Reviewed = 1,
+        Closed = 2,
+    }
+}

--- a/WSIST/WSIST.Engine/FeedbackManagement.cs
+++ b/WSIST/WSIST.Engine/FeedbackManagement.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace WSIST.Engine;
+
+public class FeedbackManagement
+{
+    private readonly WsistContext context;
+
+    public FeedbackManagement(WsistContext context)
+    {
+        this.context = context;
+    }
+
+    public Feedback Submit(int userId, string message, Feedback.FeedbackCategory category)
+    {
+        var trimmed = message?.Trim() ?? string.Empty;
+        if (trimmed.Length == 0)
+            throw new ArgumentException("Feedback message cannot be empty.", nameof(message));
+
+        // Defensively cap to the column length so an over-long message surfaces
+        // as a validation error rather than a DbUpdateException at SaveChanges.
+        if (trimmed.Length > 4000)
+            throw new ArgumentException(
+                "Feedback message is too long (4000 characters max).",
+                nameof(message)
+            );
+
+        if (!Enum.IsDefined(category))
+            throw new ArgumentException("Unknown feedback category.", nameof(category));
+
+        var feedback = new Feedback
+        {
+            UserId = userId,
+            Message = trimmed,
+            Category = category,
+            Status = Feedback.FeedbackStatus.Open,
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Feedbacks.Add(feedback);
+        context.SaveChanges();
+        return feedback;
+    }
+
+    // Admin-only listing. Authorization (is the caller the owner?) is enforced
+    // by the page that calls this — the engine intentionally has no notion of
+    // who the admin is, so it stays config-driven in the web layer.
+    public List<FeedbackView> GetAll()
+    {
+        return context
+            .Feedbacks.AsNoTracking()
+            .OrderByDescending(f => f.CreatedAt)
+            .Select(f => new FeedbackView(
+                f.Id,
+                f.Message,
+                f.Category,
+                f.Status,
+                f.CreatedAt,
+                f.User != null ? f.User.DisplayName : "(unknown)",
+                f.User != null ? f.User.Email : ""
+            ))
+            .ToList();
+    }
+
+    public record FeedbackView(
+        int Id,
+        string Message,
+        Feedback.FeedbackCategory Category,
+        Feedback.FeedbackStatus Status,
+        DateTime CreatedAt,
+        string SubmittedByName,
+        string SubmittedByEmail
+    );
+}

--- a/WSIST/WSIST.Engine/FeedbackManagement.cs
+++ b/WSIST/WSIST.Engine/FeedbackManagement.cs
@@ -49,6 +49,8 @@ public class FeedbackManagement
         return context
             .Feedbacks.AsNoTracking()
             .OrderByDescending(f => f.CreatedAt)
+            // Tie-break on Id so equal timestamps order stably.
+            .ThenByDescending(f => f.Id)
             .Select(f => new FeedbackView(
                 f.Id,
                 f.Message,

--- a/WSIST/WSIST.Engine/FeedbackManagement.cs
+++ b/WSIST/WSIST.Engine/FeedbackManagement.cs
@@ -63,6 +63,21 @@ public class FeedbackManagement
             .ToList();
     }
 
+    // Update a submission's workflow status (Open/Reviewed/Closed). Admin-only;
+    // the calling page enforces that. Returns false if the row no longer exists.
+    public bool UpdateStatus(int feedbackId, Feedback.FeedbackStatus status)
+    {
+        if (!Enum.IsDefined(status))
+            throw new ArgumentException("Unknown feedback status.", nameof(status));
+
+        var feedback = context.Feedbacks.Find(feedbackId);
+        if (feedback is null)
+            return false;
+        feedback.Status = status;
+        context.SaveChanges();
+        return true;
+    }
+
     public record FeedbackView(
         int Id,
         string Message,

--- a/WSIST/WSIST.Engine/FeedbackManagement.cs
+++ b/WSIST/WSIST.Engine/FeedbackManagement.cs
@@ -41,6 +41,26 @@ public class FeedbackManagement
         return feedback;
     }
 
+    // A user's own submissions (newest first) for their feedback history.
+    public List<FeedbackView> GetForUser(int userId)
+    {
+        return context
+            .Feedbacks.AsNoTracking()
+            .Where(f => f.UserId == userId)
+            .OrderByDescending(f => f.CreatedAt)
+            .ThenByDescending(f => f.Id)
+            .Select(f => new FeedbackView(
+                f.Id,
+                f.Message,
+                f.Category,
+                f.Status,
+                f.CreatedAt,
+                f.User != null ? f.User.DisplayName : "(unknown)",
+                f.User != null ? f.User.Email : ""
+            ))
+            .ToList();
+    }
+
     // Admin-only listing. Authorization (is the caller the owner?) is enforced
     // by the page that calls this — the engine intentionally has no notion of
     // who the admin is, so it stays config-driven in the web layer.

--- a/WSIST/WSIST.Engine/Migrations/20260617062848_AddFeedbackTable.Designer.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260617062848_AddFeedbackTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WSIST.Engine;
 
@@ -11,9 +12,11 @@ using WSIST.Engine;
 namespace WSIST.Engine.Migrations
 {
     [DbContext(typeof(WsistContext))]
-    partial class WsistContextModelSnapshot : ModelSnapshot
+    [Migration("20260617062848_AddFeedbackTable")]
+    partial class AddFeedbackTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WSIST/WSIST.Engine/Migrations/20260617062848_AddFeedbackTable.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260617062848_AddFeedbackTable.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WSIST.Engine.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeedbackTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Feedbacks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    Message = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Category = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Feedbacks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Feedbacks_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Feedbacks_CreatedAt",
+                table: "Feedbacks",
+                column: "CreatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Feedbacks_UserId",
+                table: "Feedbacks",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Feedbacks");
+        }
+    }
+}

--- a/WSIST/WSIST.Engine/Migrations/20260617064345_AddUserPreferredLanguage.Designer.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260617064345_AddUserPreferredLanguage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WSIST.Engine;
 
@@ -11,9 +12,11 @@ using WSIST.Engine;
 namespace WSIST.Engine.Migrations
 {
     [DbContext(typeof(WsistContext))]
-    partial class WsistContextModelSnapshot : ModelSnapshot
+    [Migration("20260617064345_AddUserPreferredLanguage")]
+    partial class AddUserPreferredLanguage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WSIST/WSIST.Engine/Migrations/20260617064345_AddUserPreferredLanguage.cs
+++ b/WSIST/WSIST.Engine/Migrations/20260617064345_AddUserPreferredLanguage.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WSIST.Engine.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPreferredLanguage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PreferredLanguage",
+                table: "Users",
+                type: "varchar(5)",
+                maxLength: 5,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreferredLanguage",
+                table: "Users");
+        }
+    }
+}

--- a/WSIST/WSIST.Engine/TestExporter.cs
+++ b/WSIST/WSIST.Engine/TestExporter.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using System.Text;
+
+namespace WSIST.Engine;
+
+/// <summary>
+/// One row of a user's data export. Holds typed values so JSON keeps real
+/// types (ISO date, numeric grade) while CSV formats them itself.
+/// </summary>
+public record TestExportRow(
+    string Title,
+    string Subject,
+    DateOnly DueDate,
+    string Volume,
+    string Understanding,
+    double? Grade
+);
+
+public static class TestExporter
+{
+    private static readonly string[] Header =
+    [
+        "Title",
+        "Subject",
+        "DueDate",
+        "Volume",
+        "Understanding",
+        "Grade",
+    ];
+
+    /// <summary>
+    /// Serialises export rows to RFC 4180 CSV (CRLF line endings, quoted
+    /// fields where needed) with formula-injection mitigation on the free-text
+    /// columns.
+    /// </summary>
+    public static string ToCsv(IReadOnlyList<TestExportRow> rows)
+    {
+        var sb = new StringBuilder();
+        sb.Append(string.Join(',', Header.Select(Field))).Append("\r\n");
+
+        foreach (var r in rows)
+        {
+            sb.Append(Field(r.Title))
+                .Append(',')
+                .Append(Field(r.Subject))
+                .Append(',')
+                .Append(r.DueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))
+                .Append(',')
+                .Append(Field(r.Volume))
+                .Append(',')
+                .Append(Field(r.Understanding))
+                .Append(',')
+                .Append(r.Grade?.ToString(CultureInfo.InvariantCulture) ?? "")
+                .Append("\r\n");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Field(string value)
+    {
+        var v = value ?? "";
+
+        // Formula-injection mitigation: a cell beginning with =, +, -, @, or a
+        // control character can be executed by spreadsheet apps. Prefix with a
+        // single quote so it is treated as literal text. Titles and custom
+        // subject names are user-controlled, so this matters.
+        if (v.Length > 0 && v[0] is '=' or '+' or '-' or '@' or '\t' or '\r')
+            v = "'" + v;
+
+        // RFC 4180: quote fields containing the delimiter, a quote, or a newline,
+        // doubling any embedded quotes.
+        if (v.Contains('"') || v.Contains(',') || v.Contains('\n') || v.Contains('\r'))
+            v = "\"" + v.Replace("\"", "\"\"") + "\"";
+
+        return v;
+    }
+}

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -185,6 +185,25 @@ public class TestManagement
         context.SaveChanges();
     }
 
+    public void UpdatePreferredLanguage(int userId, string? language)
+    {
+        var user = context.Users.Find(userId);
+        if (user is null)
+            return;
+        user.PreferredLanguage = language;
+        context.SaveChanges();
+    }
+
+    // Used by the request-localization provider to resolve a signed-in user's
+    // stored language without materializing the whole User entity.
+    public string? GetPreferredLanguageByEmail(string email)
+    {
+        return context
+            .Users.Where(u => u.Email == email)
+            .Select(u => u.PreferredLanguage)
+            .FirstOrDefault();
+    }
+
     public User GetOrCreateUser(string email, string displayName, string googleId)
     {
         if (string.IsNullOrWhiteSpace(email))

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+
 namespace WSIST.Engine;
 
 public class TestManagement
@@ -195,13 +197,18 @@ public class TestManagement
     }
 
     // Used by the request-localization provider to resolve a signed-in user's
-    // stored language without materializing the whole User entity.
-    public string? GetPreferredLanguageByEmail(string email)
+    // stored language without materializing the whole User entity. Async so the
+    // provider (which runs first on every authenticated request) never blocks on
+    // database I/O.
+    public Task<string?> GetPreferredLanguageByEmailAsync(
+        string email,
+        CancellationToken cancellationToken = default
+    )
     {
         return context
             .Users.Where(u => u.Email == email)
             .Select(u => u.PreferredLanguage)
-            .FirstOrDefault();
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     public User GetOrCreateUser(string email, string displayName, string googleId)

--- a/WSIST/WSIST.Engine/TestManagement.cs
+++ b/WSIST/WSIST.Engine/TestManagement.cs
@@ -257,4 +257,32 @@ public class TestManagement
             .OrderBy(x => x.SubjectName)
             .ToList();
     }
+
+    /// <summary>
+    /// Every test belonging to the user — past and future, graded or not —
+    /// shaped for a data-portability export with subject names resolved and
+    /// enum values rendered to readable text. Strictly scoped to
+    /// <paramref name="userId"/>: another user's rows can never appear.
+    /// </summary>
+    public List<TestExportRow> GetTestExport(int userId)
+    {
+        var subjects = context
+            .Subjects.Where(s => s.IsSystem || s.UserId == userId)
+            .ToDictionary(s => s.Id, s => s.Name);
+
+        return context
+            .Tests.Where(t => t.UserId == userId)
+            .AsEnumerable()
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Title)
+            .Select(t => new TestExportRow(
+                t.Title,
+                subjects.TryGetValue(t.Subject, out var name) ? name : t.Subject.ToString(),
+                t.DueDate,
+                Test.VolumeHelper(t.Volume),
+                Test.UnderstandingHelper(t.Understanding),
+                t.Grade
+            ))
+            .ToList();
+    }
 }

--- a/WSIST/WSIST.Engine/User.cs
+++ b/WSIST/WSIST.Engine/User.cs
@@ -7,6 +7,11 @@ public class User
     public string DisplayName { get; set; } = string.Empty;
     public string GoogleId { get; set; } = string.Empty;
 
+    // Two-letter culture code ("en"/"de") for the UI language. Null until the
+    // user explicitly picks one — while null the language is derived from the
+    // browser's Accept-Language header on each request.
+    public string? PreferredLanguage { get; set; }
+
     // Default so a User created without an explicit timestamp never persists
     // DateTime.MinValue (0001-01-01).
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/WSIST/WSIST.Engine/WsistContext.cs
+++ b/WSIST/WSIST.Engine/WsistContext.cs
@@ -140,6 +140,7 @@ public class WsistContext : DbContext
             entity.HasIndex(e => e.Email).IsUnique();
             entity.Property(e => e.GoogleId).HasMaxLength(100);
             entity.Property(e => e.DisplayName).HasMaxLength(100);
+            entity.Property(e => e.PreferredLanguage).HasMaxLength(5);
         });
     }
 }

--- a/WSIST/WSIST.Engine/WsistContext.cs
+++ b/WSIST/WSIST.Engine/WsistContext.cs
@@ -10,6 +10,7 @@ public class WsistContext : DbContext
     public DbSet<Test> Tests { get; set; }
     public DbSet<User> Users { get; set; }
     public DbSet<Subject> Subjects { get; set; }
+    public DbSet<Feedback> Feedbacks { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -109,6 +110,27 @@ public class WsistContext : DbContext
                     IsSystem = true,
                 }
             );
+        });
+
+        modelBuilder.Entity<Feedback>(entity =>
+        {
+            entity.ToTable("Feedbacks");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
+            entity.Property(e => e.Message).HasMaxLength(4000).IsRequired();
+            // Store enums as ints, consistent with Test.Volume/Understanding.
+            entity.Property(e => e.Category).HasConversion<int>();
+            entity.Property(e => e.Status).HasConversion<int>();
+
+            // Deleting a user removes their feedback too (they own the rows).
+            entity
+                .HasOne(f => f.User)
+                .WithMany()
+                .HasForeignKey(f => f.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // The admin listing orders newest-first; index the sort column.
+            entity.HasIndex(e => e.CreatedAt);
         });
 
         modelBuilder.Entity<User>(entity =>

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -655,4 +655,106 @@ public class UnitTests
         //a leading '=' must be neutralised so spreadsheets treat it as text
         Assert.That(csv, Does.Contain("'=SUM(A1:A2)"));
     }
+
+    [Test]
+    public void SubmitFeedback_PersistsTrimmedOpenRow()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var feedback = new FeedbackManagement(context);
+
+        //act
+        var saved = feedback.Submit(
+            user.Id,
+            "  Please add dark mode  ",
+            Feedback.FeedbackCategory.Feature
+        );
+
+        //assert
+        Assert.That(saved.Id, Is.GreaterThan(0));
+        var row = context.Feedbacks.Single();
+        Assert.That(row.Message, Is.EqualTo("Please add dark mode"));
+        Assert.That(row.Category, Is.EqualTo(Feedback.FeedbackCategory.Feature));
+        Assert.That(row.Status, Is.EqualTo(Feedback.FeedbackStatus.Open));
+        Assert.That(row.UserId, Is.EqualTo(user.Id));
+    }
+
+    [Test]
+    public void SubmitFeedback_EmptyMessage_Throws()
+    {
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var feedback = new FeedbackManagement(context);
+
+        Assert.Throws<ArgumentException>(() =>
+            feedback.Submit(user.Id, "   ", Feedback.FeedbackCategory.Bug)
+        );
+        Assert.That(context.Feedbacks.Any(), Is.False);
+    }
+
+    [Test]
+    public void SubmitFeedback_TooLongMessage_Throws()
+    {
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var feedback = new FeedbackManagement(context);
+
+        var tooLong = new string('x', 4001);
+        Assert.Throws<ArgumentException>(() =>
+            feedback.Submit(user.Id, tooLong, Feedback.FeedbackCategory.Bug)
+        );
+    }
+
+    [Test]
+    public void SubmitFeedback_UndefinedCategory_Throws()
+    {
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var feedback = new FeedbackManagement(context);
+
+        Assert.Throws<ArgumentException>(() =>
+            feedback.Submit(user.Id, "Valid message", (Feedback.FeedbackCategory)99)
+        );
+    }
+
+    [Test]
+    public void GetAllFeedback_ReturnsNewestFirstWithSubmitterInfo()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        // Insert directly with explicit timestamps so ordering is deterministic
+        // (Submit stamps DateTime.UtcNow, which two quick calls could tie on).
+        context.Feedbacks.Add(
+            new Feedback
+            {
+                UserId = user.Id,
+                Message = "older",
+                Category = Feedback.FeedbackCategory.Bug,
+                CreatedAt = new DateTime(2026, 01, 01, 0, 0, 0, DateTimeKind.Utc),
+            }
+        );
+        context.Feedbacks.Add(
+            new Feedback
+            {
+                UserId = user.Id,
+                Message = "newer",
+                Category = Feedback.FeedbackCategory.Feature,
+                CreatedAt = new DateTime(2026, 02, 01, 0, 0, 0, DateTimeKind.Utc),
+            }
+        );
+        context.SaveChanges();
+        var feedback = new FeedbackManagement(context);
+
+        //act
+        var all = feedback.GetAll();
+
+        //assert — newest first, submitter name/email resolved
+        Assert.That(all, Has.Count.EqualTo(2));
+        Assert.That(all[0].Message, Is.EqualTo("newer"));
+        Assert.That(all[1].Message, Is.EqualTo("older"));
+        Assert.That(all[0].SubmittedByName, Is.EqualTo("Test User"));
+        Assert.That(all[0].SubmittedByEmail, Is.EqualTo("test@example.com"));
+    }
 }

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -786,4 +786,31 @@ public class UnitTests
         var feedback = new FeedbackManagement(context);
         Assert.That(feedback.UpdateStatus(999, Feedback.FeedbackStatus.Closed), Is.False);
     }
+
+    [Test]
+    public void GetForUser_ReturnsOnlyTheUsersOwnFeedback()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var other = new User
+        {
+            Email = "other@example.com",
+            DisplayName = "Other",
+            GoogleId = "google-456",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(other);
+        context.SaveChanges();
+        var feedback = new FeedbackManagement(context);
+        feedback.Submit(user.Id, "Mine", Feedback.FeedbackCategory.Bug);
+        feedback.Submit(other.Id, "Theirs", Feedback.FeedbackCategory.Other);
+
+        //act
+        var mine = feedback.GetForUser(user.Id);
+
+        //assert — strictly scoped to the requesting user
+        Assert.That(mine, Has.Count.EqualTo(1));
+        Assert.That(mine[0].Message, Is.EqualTo("Mine"));
+    }
 }

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -757,4 +757,33 @@ public class UnitTests
         Assert.That(all[0].SubmittedByName, Is.EqualTo("Test User"));
         Assert.That(all[0].SubmittedByEmail, Is.EqualTo("test@example.com"));
     }
+
+    [Test]
+    public void UpdateStatus_ChangesStatusAndPersists()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var feedback = new FeedbackManagement(context);
+        var saved = feedback.Submit(user.Id, "A bug", Feedback.FeedbackCategory.Bug);
+        Assert.That(saved.Status, Is.EqualTo(Feedback.FeedbackStatus.Open));
+
+        //act
+        var ok = feedback.UpdateStatus(saved.Id, Feedback.FeedbackStatus.Reviewed);
+
+        //assert
+        Assert.That(ok, Is.True);
+        Assert.That(
+            context.Feedbacks.Single().Status,
+            Is.EqualTo(Feedback.FeedbackStatus.Reviewed)
+        );
+    }
+
+    [Test]
+    public void UpdateStatus_ReturnsFalseForMissingRow()
+    {
+        using var context = CreateContext();
+        var feedback = new FeedbackManagement(context);
+        Assert.That(feedback.UpdateStatus(999, Feedback.FeedbackStatus.Closed), Is.False);
+    }
 }

--- a/WSIST/WSIST.UnitTests/UnitTests.cs
+++ b/WSIST/WSIST.UnitTests/UnitTests.cs
@@ -540,4 +540,119 @@ public class UnitTests
         //assert
         Assert.That(created.UserId, Is.EqualTo(otherUser.Id));
     }
+
+    [Test]
+    public void GetTestExport_OnlyIncludesRequestingUsersTests()
+    {
+        //arrange
+        using var context = CreateContext();
+        var owner = SeedUser(context);
+        var other = new User
+        {
+            Email = "other@example.com",
+            DisplayName = "Other",
+            GoogleId = "google-456",
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(other);
+        context.SaveChanges();
+        var subjectId = SeedSystemSubject(context);
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Owner Test",
+            subjectId,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            owner.Id
+        );
+        manager.NewTestMaker(
+            "Other Test",
+            subjectId,
+            new DateOnly(2026, 12, 01),
+            Test.TestVolume.Medium,
+            Test.PersonalUnderstanding.Medium,
+            null,
+            other.Id
+        );
+
+        //act
+        var export = manager.GetTestExport(owner.Id);
+
+        //assert — the export is strictly scoped to the requesting user
+        Assert.That(export.Any(r => r.Title == "Owner Test"));
+        Assert.That(export.Any(r => r.Title == "Other Test"), Is.False);
+    }
+
+    [Test]
+    public void GetTestExport_IncludesPastGradedTestsWithResolvedSubjectName()
+    {
+        //arrange
+        using var context = CreateContext();
+        var user = SeedUser(context);
+        var subjectId = SeedSystemSubject(context, "Math");
+        var manager = new TestManagement(context);
+        manager.NewTestMaker(
+            "Past Exam",
+            subjectId,
+            new DateOnly(2025, 01, 01),
+            Test.TestVolume.High,
+            Test.PersonalUnderstanding.Low,
+            5.5,
+            user.Id
+        );
+
+        //act
+        var export = manager.GetTestExport(user.Id);
+
+        //assert
+        var row = export.Single(r => r.Title == "Past Exam");
+        Assert.That(row.Subject, Is.EqualTo("Math"));
+        Assert.That(row.Grade, Is.EqualTo(5.5));
+        Assert.That(row.Volume, Is.EqualTo("High"));
+    }
+
+    [Test]
+    public void ToCsv_WritesHeaderAndFormatsValues()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("Exam", "Math", new DateOnly(2026, 03, 01), "High", "Low", 5.5),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        Assert.That(csv, Does.StartWith("Title,Subject,DueDate,Volume,Understanding,Grade"));
+        Assert.That(csv, Does.Contain("2026-03-01"));
+        Assert.That(csv, Does.Contain("5.5"));
+    }
+
+    [Test]
+    public void ToCsv_EscapesDelimitersAndQuotes()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("Title, comma", "Sub \"quote\"", new DateOnly(2026, 03, 01), "High", "Low", null),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        Assert.That(csv, Does.Contain("\"Title, comma\""));
+        Assert.That(csv, Does.Contain("\"Sub \"\"quote\"\"\""));
+    }
+
+    [Test]
+    public void ToCsv_MitigatesFormulaInjection()
+    {
+        var rows = new List<TestExportRow>
+        {
+            new("=SUM(A1:A2)", "Math", new DateOnly(2026, 03, 01), "High", "Low", null),
+        };
+
+        var csv = TestExporter.ToCsv(rows);
+
+        //a leading '=' must be neutralised so spreadsheets treat it as text
+        Assert.That(csv, Does.Contain("'=SUM(A1:A2)"));
+    }
 }

--- a/WSIST/WSIST.Web/Components/App.razor
+++ b/WSIST/WSIST.Web/Components/App.razor
@@ -1,5 +1,6 @@
-﻿<!DOCTYPE html>
-<html lang="en">
+﻿@using System.Globalization
+<!DOCTYPE html>
+<html lang="@CultureInfo.CurrentUICulture.TwoLetterISOLanguageName">
 
 <head>
     <meta charset="utf-8"/>

--- a/WSIST/WSIST.Web/Components/LanguageToggle.razor
+++ b/WSIST/WSIST.Web/Components/LanguageToggle.razor
@@ -1,10 +1,11 @@
 @using System.Globalization
 @inject NavigationManager Nav
+@inject IStringLocalizer<SharedResource> Localizer
 
 @* EN / DE switch. Each link is a full (non-enhanced) navigation to the
    set-language endpoint, which writes the culture cookie + saves the
    preference, then redirects back to the current page. *@
-<div class="lang-toggle" role="group" aria-label="Language">
+<div class="lang-toggle" role="group" aria-label="@Localizer["Language"]">
     <a href="/set-language/en?redirectUri=@CurrentPath"
        class="lang-option @(IsGerman ? "" : "active")"
        data-enhance-nav="false" hreflang="en">EN</a>

--- a/WSIST/WSIST.Web/Components/LanguageToggle.razor
+++ b/WSIST/WSIST.Web/Components/LanguageToggle.razor
@@ -1,0 +1,23 @@
+@using System.Globalization
+@inject NavigationManager Nav
+
+@* EN / DE switch. Each link is a full (non-enhanced) navigation to the
+   set-language endpoint, which writes the culture cookie + saves the
+   preference, then redirects back to the current page. *@
+<div class="lang-toggle" role="group" aria-label="Language">
+    <a href="/set-language/en?redirectUri=@CurrentPath"
+       class="lang-option @(IsGerman ? "" : "active")"
+       data-enhance-nav="false" hreflang="en">EN</a>
+    <span class="lang-sep" aria-hidden="true">/</span>
+    <a href="/set-language/de?redirectUri=@CurrentPath"
+       class="lang-option @(IsGerman ? "active" : "")"
+       data-enhance-nav="false" hreflang="de">DE</a>
+</div>
+
+@code {
+    private bool IsGerman => CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "de";
+
+    // Local relative path (with leading slash) for the round-trip redirect.
+    private string CurrentPath =>
+        Uri.EscapeDataString("/" + Nav.ToBaseRelativePath(Nav.Uri));
+}

--- a/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
+++ b/WSIST/WSIST.Web/Components/Pages/AuthenticatedComponentBase.cs
@@ -13,6 +13,11 @@ public abstract class AuthenticatedComponentBase(
 {
     protected int CurrentUserId { get; private set; }
 
+    // The authenticated user's email claim, exposed so pages can do
+    // owner/admin gating (e.g. the feedback listing) without re-reading the
+    // auth state themselves.
+    protected string? CurrentUserEmail { get; private set; }
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await authStateProvider.GetAuthenticationStateAsync();
@@ -40,6 +45,7 @@ public abstract class AuthenticatedComponentBase(
         {
             var dbUser = management.GetOrCreateUser(email, name, googleId);
             CurrentUserId = dbUser.Id;
+            CurrentUserEmail = dbUser.Email;
         }
         catch (Exception)
         {

--- a/WSIST/WSIST.Web/Components/Pages/Error.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Error.razor
@@ -1,13 +1,14 @@
 @page "/Error"
 @layout EmptyLayout
 @using WSIST.Web.Components.Layout
-<PageTitle>Error – WSIST</PageTitle>
+@inject IStringLocalizer<SharedResource> Localizer
+<PageTitle>@Localizer["Error_Title"] – WSIST</PageTitle>
 
 <div class="error-page">
     <div class="error-content">
         <span class="error-icon" aria-hidden="true">⚠</span>
-        <h1 class="error-title">Something went wrong</h1>
-        <p class="error-sub">An unexpected error occurred. If this keeps happening, try logging out and back in.</p>
-        <a href="/" class="button-primary button-accent" data-enhance-nav="false">← Back to home</a>
+        <h1 class="error-title">@Localizer["Error_Title"]</h1>
+        <p class="error-sub">@Localizer["Error_Sub"]</p>
+        <a href="/" class="button-primary button-accent" data-enhance-nav="false">← @Localizer["Common_BackToHome"]</a>
     </div>
 </div>

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
@@ -1,0 +1,92 @@
+@page "/feedback"
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@inherits AuthenticatedComponentBase
+@using WSIST.Engine
+<PageTitle>WSIST — Feedback</PageTitle>
+
+<div class="page">
+    <div class="top-row">
+        <div class="title nav-brand">
+            <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
+            <span>WSIST</span>
+        </div>
+        <a href="/" class="button-primary" data-enhance-nav="false">← Back</a>
+        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
+    </div>
+
+    <div class="content px-4">
+        <div class="settings-page-header">
+            <h1>Feedback</h1>
+            <p>Found a bug or have an idea? Let me know.</p>
+        </div>
+
+        <div class="settings-block">
+            <p class="settings-block-label">Submit feedback</p>
+            <div class="settings-card">
+                <div class="feedback-form">
+                    <label class="feedback-label" for="feedback-category">Category</label>
+                    <select id="feedback-category" class="settings-input" @bind="category">
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Bug">Bug</option>
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Feature">Feature request</option>
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Other">Other</option>
+                    </select>
+
+                    <label class="feedback-label" for="feedback-message">Message</label>
+                    <textarea id="feedback-message" class="settings-input feedback-textarea"
+                              maxlength="4000" rows="6"
+                              placeholder="Describe the bug or your idea…"
+                              @bind="message" @bind:event="oninput"></textarea>
+
+                    <div class="feedback-actions">
+                        <button class="button-primary button-accent" @onclick="SubmitFeedback" disabled="@isSubmitting">
+                            @(isSubmitting ? "Sending…" : "Send feedback")
+                        </button>
+                    </div>
+
+                    @if (submitError is not null)
+                    {
+                        <small class="settings-error">@submitError</small>
+                    }
+                    @if (submitMessage is not null)
+                    {
+                        <small class="settings-success">@submitMessage</small>
+                    }
+                </div>
+            </div>
+        </div>
+
+        @if (isAdmin)
+        {
+            <div class="settings-block">
+                <p class="settings-block-label">All submissions (admin)</p>
+                <div class="settings-card">
+                    @if (allFeedback.Count == 0)
+                    {
+                        <p class="feedback-empty">No feedback submitted yet.</p>
+                    }
+                    else
+                    {
+                        @foreach (var item in allFeedback)
+                        {
+                            <div class="feedback-item">
+                                <div class="feedback-item-head">
+                                    <span class="subject-badge feedback-cat-@item.Category.ToString().ToLowerInvariant()">@item.Category</span>
+                                    <span class="feedback-meta">
+                                        @item.SubmittedByName
+                                        @if (!string.IsNullOrEmpty(item.SubmittedByEmail))
+                                        {
+                                            <span class="feedback-email">(@item.SubmittedByEmail)</span>
+                                        }
+                                        · @item.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC
+                                        · @item.Status
+                                    </span>
+                                </div>
+                                <p class="feedback-item-message">@item.Message</p>
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
@@ -2,7 +2,7 @@
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @inherits AuthenticatedComponentBase
 @using WSIST.Engine
-<PageTitle>WSIST — Feedback</PageTitle>
+<PageTitle>WSIST — @localizer["Feedback_Title"]</PageTitle>
 
 <div class="page">
     <div class="top-row">
@@ -10,36 +10,37 @@
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
         </div>
-        <a href="/" class="button-primary" data-enhance-nav="false">← Back</a>
-        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
+        <LanguageToggle />
+        <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
+        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>
     </div>
 
     <div class="content px-4">
         <div class="settings-page-header">
-            <h1>Feedback</h1>
-            <p>Found a bug or have an idea? Let me know.</p>
+            <h1>@localizer["Feedback_Title"]</h1>
+            <p>@localizer["Feedback_Subtitle"]</p>
         </div>
 
         <div class="settings-block">
-            <p class="settings-block-label">Submit feedback</p>
+            <p class="settings-block-label">@localizer["Feedback_Submit"]</p>
             <div class="settings-card">
                 <div class="feedback-form">
-                    <label class="feedback-label" for="feedback-category">Category</label>
+                    <label class="feedback-label" for="feedback-category">@localizer["Feedback_Category"]</label>
                     <select id="feedback-category" class="settings-input" @bind="category">
-                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Bug">Bug</option>
-                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Feature">Feature request</option>
-                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Other">Other</option>
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Bug">@localizer["Feedback_CategoryBug"]</option>
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Feature">@localizer["Feedback_CategoryFeature"]</option>
+                        <option value="@WSIST.Engine.Feedback.FeedbackCategory.Other">@localizer["Feedback_CategoryOther"]</option>
                     </select>
 
-                    <label class="feedback-label" for="feedback-message">Message</label>
+                    <label class="feedback-label" for="feedback-message">@localizer["Feedback_Message"]</label>
                     <textarea id="feedback-message" class="settings-input feedback-textarea"
                               maxlength="4000" rows="6"
-                              placeholder="Describe the bug or your idea…"
+                              placeholder="@localizer["Feedback_MessagePlaceholder"]"
                               @bind="message" @bind:event="oninput"></textarea>
 
                     <div class="feedback-actions">
                         <button class="button-primary button-accent" @onclick="SubmitFeedback" disabled="@isSubmitting">
-                            @(isSubmitting ? "Sending…" : "Send feedback")
+                            @(isSubmitting ? localizer["Feedback_Sending"] : localizer["Feedback_Send"])
                         </button>
                     </div>
 
@@ -58,11 +59,11 @@
         @if (isAdmin)
         {
             <div class="settings-block">
-                <p class="settings-block-label">All submissions (admin)</p>
+                <p class="settings-block-label">@localizer["Feedback_AdminTitle"]</p>
                 <div class="settings-card">
                     @if (allFeedback.Count == 0)
                     {
-                        <p class="feedback-empty">No feedback submitted yet.</p>
+                        <p class="feedback-empty">@localizer["Feedback_Empty"]</p>
                     }
                     else
                     {
@@ -70,7 +71,7 @@
                         {
                             <div class="feedback-item">
                                 <div class="feedback-item-head">
-                                    <span class="subject-badge feedback-cat-@item.Category.ToString().ToLowerInvariant()">@item.Category</span>
+                                    <span class="subject-badge feedback-cat-@item.Category.ToString().ToLowerInvariant()">@localizer[$"Feedback_Category{item.Category}"]</span>
                                     <span class="feedback-meta">
                                         @item.SubmittedByName
                                         @if (!string.IsNullOrEmpty(item.SubmittedByEmail))
@@ -78,7 +79,7 @@
                                             <span class="feedback-email">(@item.SubmittedByEmail)</span>
                                         }
                                         · @item.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC
-                                        · @item.Status
+                                        · @localizer[$"Feedback_Status{item.Status}"]
                                     </span>
                                 </div>
                                 <p class="feedback-item-message">@item.Message</p>

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
@@ -6,10 +6,10 @@
 
 <div class="page">
     <div class="top-row">
-        <div class="title nav-brand">
+        <a href="/" class="title nav-brand" data-enhance-nav="false">
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
-        </div>
+        </a>
         <LanguageToggle />
         <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
         <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>
@@ -79,8 +79,13 @@
                                             <span class="feedback-email">(@item.SubmittedByEmail)</span>
                                         }
                                         · @item.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC
-                                        · @localizer[$"Feedback_Status{item.Status}"]
                                     </span>
+                                    <select class="feedback-status-select" @onchange="(e) => ChangeStatus(item.Id, e)" aria-label="@localizer["Feedback_StatusLabel"]">
+                                        @foreach (var st in Enum.GetValues<Feedback.FeedbackStatus>())
+                                        {
+                                            <option value="@st" selected="@(st == item.Status)">@localizer[$"Feedback_Status{st}"]</option>
+                                        }
+                                    </select>
                                 </div>
                                 <p class="feedback-item-message">@item.Message</p>
                             </div>

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor
@@ -56,6 +56,30 @@
             </div>
         </div>
 
+        <div class="settings-block">
+            <p class="settings-block-label">@localizer["Feedback_YourSubmissions"]</p>
+            <div class="settings-card">
+                @if (myFeedback.Count == 0)
+                {
+                    <p class="feedback-empty">@localizer["Feedback_YourEmpty"]</p>
+                }
+                else
+                {
+                    @foreach (var item in myFeedback)
+                    {
+                        <div class="feedback-item">
+                            <div class="feedback-item-head">
+                                <span class="subject-badge feedback-cat-@item.Category.ToString().ToLowerInvariant()">@localizer[$"Feedback_Category{item.Category}"]</span>
+                                <span class="feedback-meta">@item.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC</span>
+                                <span class="feedback-status-tag">@localizer[$"Feedback_Status{item.Status}"]</span>
+                            </div>
+                            <p class="feedback-item-message">@item.Message</p>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
         @if (isAdmin)
         {
             <div class="settings-block">

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using WSIST.Engine;
+
+namespace WSIST.Web.Components.Pages;
+
+public partial class FeedbackPage(
+    TestManagement management,
+    FeedbackManagement feedbackManagement,
+    AuthenticationStateProvider authStateProvider,
+    NavigationManager navigation,
+    IConfiguration configuration
+) : AuthenticatedComponentBase(management, authStateProvider, navigation)
+{
+    private Feedback.FeedbackCategory category = Feedback.FeedbackCategory.Bug;
+    private string message = string.Empty;
+    private bool isSubmitting;
+    private string? submitError;
+    private string? submitMessage;
+
+    private bool isAdmin;
+    private List<FeedbackManagement.FeedbackView> allFeedback = [];
+
+    protected override Task OnAuthenticatedAsync()
+    {
+        // The feedback listing is gated to the configured admin account only.
+        // An unset/blank Admin:Email means nobody is admin (safe default).
+        var adminEmail = configuration["Admin:Email"];
+        isAdmin =
+            !string.IsNullOrWhiteSpace(adminEmail)
+            && string.Equals(adminEmail, CurrentUserEmail, StringComparison.OrdinalIgnoreCase);
+
+        if (isAdmin)
+            allFeedback = feedbackManagement.GetAll();
+
+        return Task.CompletedTask;
+    }
+
+    private void SubmitFeedback()
+    {
+        submitError = null;
+        submitMessage = null;
+
+        if (isSubmitting)
+            return;
+        isSubmitting = true;
+        try
+        {
+            feedbackManagement.Submit(CurrentUserId, message, category);
+        }
+        catch (ArgumentException ex)
+        {
+            submitError = ex.Message;
+            return;
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+
+        message = string.Empty;
+        category = Feedback.FeedbackCategory.Bug;
+        submitMessage = "Thanks — your feedback was submitted.";
+
+        // Reflect the new row immediately for the admin's own listing.
+        if (isAdmin)
+            allFeedback = feedbackManagement.GetAll();
+
+        StateHasChanged();
+    }
+}

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
@@ -22,6 +22,7 @@ public partial class FeedbackPage(
 
     private bool isAdmin;
     private List<FeedbackManagement.FeedbackView> allFeedback = [];
+    private List<FeedbackManagement.FeedbackView> myFeedback = [];
 
     protected override Task OnAuthenticatedAsync()
     {
@@ -32,6 +33,8 @@ public partial class FeedbackPage(
             !string.IsNullOrWhiteSpace(adminEmail)
             && string.Equals(adminEmail, CurrentUserEmail, StringComparison.OrdinalIgnoreCase);
 
+        // Every user sees their own submission history.
+        myFeedback = feedbackManagement.GetForUser(CurrentUserId);
         if (isAdmin)
             allFeedback = feedbackManagement.GetAll();
 
@@ -70,7 +73,9 @@ public partial class FeedbackPage(
         category = Feedback.FeedbackCategory.Bug;
         submitMessage = localizer["Feedback_Thanks"];
 
-        // Reflect the new row immediately for the admin's own listing.
+        // Reflect the new row immediately in the user's own history (and the
+        // admin's full listing).
+        myFeedback = feedbackManagement.GetForUser(CurrentUserId);
         if (isAdmin)
             allFeedback = feedbackManagement.GetAll();
 
@@ -86,6 +91,7 @@ public partial class FeedbackPage(
         {
             feedbackManagement.UpdateStatus(feedbackId, status);
             allFeedback = feedbackManagement.GetAll();
+            myFeedback = feedbackManagement.GetForUser(CurrentUserId);
             StateHasChanged();
         }
     }

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
@@ -52,10 +52,13 @@ public partial class FeedbackPage(
         }
         catch (ArgumentException)
         {
-            // The only ArgumentException reachable from the UI is an empty
-            // message (length is capped client-side); map it to a localized
-            // message rather than surfacing the engine's English text.
-            submitError = localizer["Feedback_EmptyError"];
+            // An empty message is the common case (length is capped client-side
+            // and the category comes from a fixed dropdown); map it to a clear
+            // localized message and fall back to a generic one for any other
+            // engine validation failure rather than surfacing English text.
+            submitError = string.IsNullOrWhiteSpace(message)
+                ? localizer["Feedback_EmptyError"]
+                : localizer["Feedback_SubmitValidationError"];
             return;
         }
         finally

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Localization;
 using WSIST.Engine;
 
 namespace WSIST.Web.Components.Pages;
@@ -9,7 +10,8 @@ public partial class FeedbackPage(
     FeedbackManagement feedbackManagement,
     AuthenticationStateProvider authStateProvider,
     NavigationManager navigation,
-    IConfiguration configuration
+    IConfiguration configuration,
+    IStringLocalizer<SharedResource> localizer
 ) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private Feedback.FeedbackCategory category = Feedback.FeedbackCategory.Bug;
@@ -48,9 +50,12 @@ public partial class FeedbackPage(
         {
             feedbackManagement.Submit(CurrentUserId, message, category);
         }
-        catch (ArgumentException ex)
+        catch (ArgumentException)
         {
-            submitError = ex.Message;
+            // The only ArgumentException reachable from the UI is an empty
+            // message (length is capped client-side); map it to a localized
+            // message rather than surfacing the engine's English text.
+            submitError = localizer["Feedback_EmptyError"];
             return;
         }
         finally
@@ -60,7 +65,7 @@ public partial class FeedbackPage(
 
         message = string.Empty;
         category = Feedback.FeedbackCategory.Bug;
-        submitMessage = "Thanks — your feedback was submitted.";
+        submitMessage = localizer["Feedback_Thanks"];
 
         // Reflect the new row immediately for the admin's own listing.
         if (isAdmin)

--- a/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/FeedbackPage.razor.cs
@@ -76,4 +76,17 @@ public partial class FeedbackPage(
 
         StateHasChanged();
     }
+
+    // Admin-only: change a submission's status from the listing.
+    private void ChangeStatus(int feedbackId, ChangeEventArgs e)
+    {
+        if (!isAdmin)
+            return;
+        if (Enum.TryParse<Feedback.FeedbackStatus>(e.Value?.ToString(), out var status))
+        {
+            feedbackManagement.UpdateStatus(feedbackId, status);
+            allFeedback = feedbackManagement.GetAll();
+            StateHasChanged();
+        }
+    }
 }

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor
@@ -11,30 +11,31 @@
             <span>WSIST</span>
         </div>
         <button class="button-primary" @onclick="Refresh">↻</button>
-        <a href="/settings" class="button-primary" data-enhance-nav="false">Settings</a>
-        <a href="/study" class="button-primary button-accent" data-enhance-nav="false">Study →</a>
-        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
+        <LanguageToggle />
+        <a href="/settings" class="button-primary" data-enhance-nav="false">@localizer["Common_Settings"]</a>
+        <a href="/study" class="button-primary button-accent" data-enhance-nav="false">@localizer["Common_Study"] →</a>
+        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>
     </div>
 
     <div class="content px-4">
 
         <div class="home-header">
             <div>
-                <h1 class="home-title">Your tests</h1>
-                <p class="home-subtitle">Upcoming exams and assessments.</p>
+                <h1 class="home-title">@localizer["Home_Title"]</h1>
+                <p class="home-subtitle">@localizer["Home_Subtitle"]</p>
             </div>
             <div class="home-header-actions">
                 <button class="button-primary" @onclick="TogglePastTests">
-                    @(showPastTests ? "Hide past" : "Show past")
+                    @(showPastTests ? localizer["Home_HidePast"] : localizer["Home_ShowPast"])
                 </button>
-                <button class="button-primary button-accent" @onclick="OpenAddTestModal">+ Add test</button>
+                <button class="button-primary button-accent" @onclick="OpenAddTestModal">+ @localizer["Home_AddTest"]</button>
             </div>
         </div>
 
         @if (MissingGrades.Any())
         {
             <div class="missing-grades-strip">
-                <span class="missing-grades-label">⏳ Enter missing grades</span>
+                <span class="missing-grades-label">⏳ @localizer["Home_EnterMissingGrades"]</span>
                 <div class="missing-grades-list">
                     @foreach (var test in MissingGrades)
                     {
@@ -53,15 +54,15 @@
             var days = topRecommendation.DueDate.DayNumber - DateOnly.FromDateTime(DateTime.Today).DayNumber;
             <div class="recommendation-widget">
                 <div class="recommendation-widget-inner">
-                    <div class="recommendation-widget-label">Study today</div>
+                    <div class="recommendation-widget-label">@localizer["Home_StudyToday"]</div>
                     <div class="recommendation-widget-body">
                         <div>
                             <div class="recommendation-widget-title">@topRecommendation.Title</div>
                             <div class="recommendation-widget-meta">
-                                @(subjects.FirstOrDefault(s => s.Id == topRecommendation.Subject)?.Name ?? "Unknown") · in @days day@(days == 1 ? "" : "s") · @score/40 pts
+                                @(subjects.FirstOrDefault(s => s.Id == topRecommendation.Subject)?.Name ?? localizer["Common_Unknown"].Value) · @(days == 1 ? localizer["Common_InOneDay"] : localizer["Common_InDaysFmt", days]) · @score/40 @localizer["Common_Points"]
                             </div>
                         </div>
-                        <a href="/study" class="button-primary button-accent" data-enhance-nav="false" style="flex-shrink:0">Full plan →</a>
+                        <a href="/study" class="button-primary button-accent" data-enhance-nav="false" style="flex-shrink:0">@localizer["Home_FullPlan"] →</a>
                     </div>
                     <div class="study-card-bar-bg">
                         <div class="study-card-bar" style="width: @(score / 40.0 * 100)%"></div>
@@ -75,8 +76,8 @@
             {
                 <div class="empty-state">
                     <p class="empty-state-icon">📋</p>
-                    <p class="empty-state-title">No upcoming tests</p>
-                    <p class="empty-state-sub">Add your first test to get started.</p>
+                    <p class="empty-state-title">@localizer["Home_NoUpcomingTitle"]</p>
+                    <p class="empty-state-sub">@localizer["Home_NoUpcomingSub"]</p>
                 </div>
             }
             else
@@ -84,11 +85,11 @@
                 <table class="table">
                     <thead>
                         <tr>
-                            <th>Title</th>
-                            <th>Subject</th>
-                            <th>Date</th>
-                            <th>Volume</th>
-                            <th>Understanding</th>
+                            <th>@localizer["Home_ColTitle"]</th>
+                            <th>@localizer["Home_ColSubject"]</th>
+                            <th>@localizer["Home_ColDate"]</th>
+                            <th>@localizer["Home_ColVolume"]</th>
+                            <th>@localizer["Home_ColUnderstanding"]</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -97,13 +98,13 @@
                         {
                             <tr>
                                 <td class="td-title">@test.Title</td>
-                                <td class="td-muted">@(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? "Unknown")</td>
+                                <td class="td-muted">@(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? localizer["Common_Unknown"].Value)</td>
                                 <td class="td-muted">@test.DueDate.ToShortDateString()</td>
-                                <td class="td-muted">@Test.VolumeHelper(test.Volume)</td>
-                                <td class="td-muted">@Test.UnderstandingHelper(test.Understanding)</td>
+                                <td class="td-muted">@localizer[$"Level_{test.Volume}"]</td>
+                                <td class="td-muted">@localizer[$"Level_{test.Understanding}"]</td>
                                 <td class="td-actions">
-                                    <button class="button-primary" @onclick="() => OpenEditTestModal(test)">Edit</button>
-                                    <button class="button-primary button-danger" @onclick="() => DeleteTest(test.Id)">Delete</button>
+                                    <button class="button-primary" @onclick="() => OpenEditTestModal(test)">@localizer["Common_Edit"]</button>
+                                    <button class="button-primary button-danger" @onclick="() => DeleteTest(test.Id)">@localizer["Common_Delete"]</button>
                                 </td>
                             </tr>
                         }
@@ -118,7 +119,7 @@
         @if (subjectAverages.Any())
         {
             <div class="grade-overview">
-                <h2 class="grade-overview-title">Grades</h2>
+                <h2 class="grade-overview-title">@localizer["Home_Grades"]</h2>
                 <div class="grade-overview-cards">
                     @foreach (var (subject, avg) in subjectAverages.OrderBy(x => x.Value))
                     {
@@ -138,7 +139,7 @@
         @if (gradeHistory.Any())
         {
             <div class="grade-trends">
-                <h2 class="grade-overview-title">Grade trends</h2>
+                <h2 class="grade-overview-title">@localizer["Home_GradeTrends"]</h2>
                 <div class="grade-trend-grid">
                     @foreach (var (subjectId, history) in gradeHistory)
                     {
@@ -184,7 +185,7 @@
                                 }
                             </svg>
                             <div class="grade-trend-footer">
-                                <span class="grade-trend-count">@history.Count test@(history.Count == 1 ? "" : "s")</span>
+                                <span class="grade-trend-count">@(history.Count == 1 ? localizer["Home_TestCountOne"] : localizer["Home_TestCountFmt", history.Count])</span>
                                 <span class="grade-trend-delta @(trend >= 0 ? "delta-up" : "delta-down")">
                                     @(trend >= 0 ? "↑" : "↓") @Math.Abs(trend).ToString("F1")
                                 </span>
@@ -200,16 +201,16 @@
             <div class="wsist-modal">
                 <div class="wsist-modal-content">
                     <div class="wsist-modal-header">
-                        <h2 class="wsist-modal-title">@(Mode == Modes.AddTest ? "Add test" : "Edit test")</h2>
+                        <h2 class="wsist-modal-title">@(Mode == Modes.AddTest ? localizer["Modal_AddTest"] : localizer["Modal_EditTest"])</h2>
                         <button class="wsist-modal-close" @onclick="CloseModal">×</button>
                     </div>
                     <form @onsubmit="ModalSubmit">
                         <div class="form-group">
-                            <label>Title</label>
-                            <input type="text" @bind="@temporaryTest.Title" placeholder="e.g. Maths Exam"/>
+                            <label>@localizer["Modal_Title"]</label>
+                            <input type="text" @bind="@temporaryTest.Title" placeholder="@localizer["Modal_TitlePlaceholder"]"/>
                         </div>
                         <div class="form-group">
-                            <label>Subject</label>
+                            <label>@localizer["Modal_Subject"]</label>
                             @if (!addingSubject)
                             {
                                 <select @bind="temporaryTest.Subject" @bind:after="OnSubjectSelectionChanged">
@@ -217,17 +218,17 @@
                                     {
                                         <option value="@subject.Id">@subject.Name</option>
                                     }
-                                    <option value="@AddNewSubjectValue">+ Add new subject</option>
+                                    <option value="@AddNewSubjectValue">@localizer["Modal_AddNewSubject"]</option>
                                 </select>
                             }
                             else
                             {
                                 <div class="inline-subject">
                                     <div class="inline-subject-row">
-                                        <input type="text" placeholder="New subject name" maxlength="100"
+                                        <input type="text" placeholder="@localizer["Modal_NewSubjectPlaceholder"]" maxlength="100"
                                                @bind="newSubjectName" @bind:event="oninput"/>
-                                        <button type="button" class="button-primary button-accent" @onclick="ConfirmAddSubject">Add</button>
-                                        <button type="button" class="button-primary" @onclick="CancelAddSubject">Cancel</button>
+                                        <button type="button" class="button-primary button-accent" @onclick="ConfirmAddSubject">@localizer["Common_Add"]</button>
+                                        <button type="button" class="button-primary" @onclick="CancelAddSubject">@localizer["Common_Cancel"]</button>
                                     </div>
                                     @if (subjectError is not null)
                                     {
@@ -237,37 +238,37 @@
                             }
                         </div>
                         <div class="form-group">
-                            <label>Due date</label>
+                            <label>@localizer["Modal_DueDate"]</label>
                             <input type="date" @bind="@temporaryTest.DueDate"/>
                         </div>
                         <div class="form-group">
-                            <label>Volume</label>
+                            <label>@localizer["Modal_Volume"]</label>
                             <select @bind="temporaryTest.Volume">
                                 @foreach (var v in Enum.GetValues<Test.TestVolume>())
                                 {
-                                    <option value="@v">@Test.VolumeHelper(v)</option>
+                                    <option value="@v">@localizer[$"Level_{v}"]</option>
                                 }
                             </select>
                         </div>
                         <div class="form-group">
-                            <label>Understanding</label>
+                            <label>@localizer["Modal_Understanding"]</label>
                             <select @bind="temporaryTest.Understanding">
                                 @foreach (var u in Enum.GetValues<Test.PersonalUnderstanding>())
                                 {
-                                    <option value="@u">@Test.UnderstandingHelper(u)</option>
+                                    <option value="@u">@localizer[$"Level_{u}"]</option>
                                 }
                             </select>
                         </div>
                         <div class="form-group">
-                            <label>Grade @(temporaryTest.DueDate > DateOnly.FromDateTime(DateTime.Today) ? "(available after test date)" : "")</label>
+                            <label>@localizer["Modal_Grade"] @(temporaryTest.DueDate > DateOnly.FromDateTime(DateTime.Today) ? localizer["Modal_GradeAfterDate"].Value : "")</label>
                             <input type="number" min="1" max="6" step="0.1"
                                    @bind="temporaryTest.Grade"
                                    disabled="@(temporaryTest.DueDate > DateOnly.FromDateTime(DateTime.Today))"/>
                         </div>
                         <div class="modal-footer">
-                            <button type="button" class="button-primary" @onclick="CloseModal">Cancel</button>
+                            <button type="button" class="button-primary" @onclick="CloseModal">@localizer["Common_Cancel"]</button>
                             <button type="submit" class="button-primary button-accent">
-                                @(Mode == Modes.AddTest ? "Add test" : "Save changes")
+                                @(Mode == Modes.AddTest ? localizer["Modal_AddTest"] : localizer["Modal_SaveChanges"])
                             </button>
                         </div>
                     </form>

--- a/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Home.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Localization;
 using WSIST.Engine;
 
 namespace WSIST.Web.Components.Pages;
@@ -8,7 +9,8 @@ public partial class Home(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
     NavigationManager navigation,
-    PriorityCalculator calculator
+    PriorityCalculator calculator,
+    IStringLocalizer<SharedResource> localizer
 ) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private List<Test> allTests = [];
@@ -154,12 +156,12 @@ public partial class Home(
         }
         catch (ArgumentException)
         {
-            subjectError = "Subject name cannot be empty.";
+            subjectError = localizer["Subject_EmptyError"];
             return;
         }
         catch (SubjectAlreadyExistsException)
         {
-            subjectError = "A subject with that name already exists.";
+            subjectError = localizer["Subject_DuplicateError"];
             return;
         }
 

--- a/WSIST/WSIST.Web/Components/Pages/Login.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Login.razor
@@ -314,7 +314,7 @@
                     <p>@Localizer["Landing_Feat5Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.3s">
-                    <h3>“WSIST sagt” <span class="soon">@Localizer["Landing_Soon"]</span></h3>
+                    <h3>@Localizer["Landing_WsistSays"] <span class="soon">@Localizer["Landing_Soon"]</span></h3>
                     <p>@Localizer["Landing_Feat6Desc"]</p>
                 </div>
             </div>
@@ -327,7 +327,7 @@
             <blockquote class="r-up js-reveal">
                 @Localizer["Landing_ManifestoPre"]<b>@Localizer["Landing_ManifestoBold"]</b>
             </blockquote>
-            <cite class="r-up js-reveal" style="--d:.12s">Tim · Informatik-Lehrling · Zürich</cite>
+            <cite class="r-up js-reveal" style="--d:.12s">@Localizer["Landing_ManifestoAttribution"]</cite>
         </div>
     </section>
 

--- a/WSIST/WSIST.Web/Components/Pages/Login.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Login.razor
@@ -1,7 +1,8 @@
 @page "/login-page"
 @layout EmptyLayout
 @using WSIST.Web.Components.Layout
-<PageTitle>WSIST — What should I study today?</PageTitle>
+@inject IStringLocalizer<SharedResource> Localizer
+<PageTitle>WSIST — @Localizer["Landing_HeroLine1"] @Localizer["Landing_HeroLine2Pre"]@Localizer["Landing_HeroLine2Em"]</PageTitle>
 
 <div class="landing">
 
@@ -10,13 +11,14 @@
         <div class="container nav-inner">
             <a class="logo" href="/login-page#top" data-enhance-nav="false" aria-label="WSIST home">
                 <span class="logo-word">WSIST<i>.</i></span>
-                <span class="logo-tag">what should I study today</span>
+                <span class="logo-tag">@Localizer["Landing_LogoTag"]</span>
             </a>
             <div class="nav-links">
-                <a href="/login-page#score" data-enhance-nav="false">The score</a>
-                <a href="/login-page#try" data-enhance-nav="false">Try it</a>
-                <a href="/login-page#how" data-enhance-nav="false">How it works</a>
-                <a class="btn btn-primary btn-sm" href="/login" data-enhance-nav="false">Sign in</a>
+                <a href="/login-page#score" data-enhance-nav="false">@Localizer["Landing_NavScore"]</a>
+                <a href="/login-page#try" data-enhance-nav="false">@Localizer["Landing_NavTry"]</a>
+                <a href="/login-page#how" data-enhance-nav="false">@Localizer["Landing_NavHow"]</a>
+                <LanguageToggle />
+                <a class="btn btn-primary btn-sm" href="/login" data-enhance-nav="false">@Localizer["Common_SignIn"]</a>
             </div>
         </div>
     </nav>
@@ -25,54 +27,52 @@
     <header class="hero" id="top">
         <div class="container hero-grid">
             <div class="hero-copy">
-                <p class="eyebrow r-up js-reveal">Free for students · Built in Zürich</p>
+                <p class="eyebrow r-up js-reveal">@Localizer["Landing_HeroEyebrow"]</p>
                 <h1>
-                    <span class="r-mask js-reveal" style="--d:.05s"><span>What should</span></span>
-                    <span class="r-mask js-reveal" style="--d:.14s"><span>I study <em>today?</em></span></span>
+                    <span class="r-mask js-reveal" style="--d:.05s"><span>@Localizer["Landing_HeroLine1"]</span></span>
+                    <span class="r-mask js-reveal" style="--d:.14s"><span>@Localizer["Landing_HeroLine2Pre"]<em>@Localizer["Landing_HeroLine2Em"]</em></span></span>
                 </h1>
                 <p class="sub r-up js-reveal" style="--d:.28s">
-                    Five subjects, three tests next week, one free evening. WSIST scores every
-                    upcoming test — urgency, volume, how well you get it, where your grades
-                    stand — and tells you exactly where tonight goes.
+                    @Localizer["Landing_HeroSub"]
                 </p>
                 <div class="hero-ctas r-up js-reveal" style="--d:.38s">
                     <a class="btn btn-primary" href="/login" data-enhance-nav="false">
                         <svg class="g-mark" viewBox="0 0 48 48" aria-hidden="true"><path fill="#FFC107" d="M43.6 20.1H42V20H24v8h11.3C33.7 32.7 29.2 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 13 4 4 13 4 24s9 20 20 20 20-9 20-20c0-1.3-.1-2.6-.4-3.9z"/><path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 15.1 19 12 24 12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 16.3 4 9.7 8.3 6.3 14.7z"/><path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.3C29.2 35.1 26.7 36 24 36c-5.2 0-9.6-3.3-11.3-8l-6.5 5C9.5 39.6 16.2 44 24 44z"/><path fill="#1976D2" d="M43.6 20.1H42V20H24v8h11.3c-.8 2.2-2.2 4.2-4.1 5.5l6.2 5.3C37 39.2 44 34 44 24c0-1.3-.1-2.6-.4-3.9z"/></svg>
-                        Continue with Google
+                        @Localizer["Common_ContinueWithGoogle"]
                     </a>
-                    <a class="btn btn-ghost" href="/login-page#score" data-enhance-nav="false">See the score ↓</a>
+                    <a class="btn btn-ghost" href="/login-page#score" data-enhance-nav="false">@Localizer["Landing_SeeScore"] ↓</a>
                 </div>
-                <p class="hero-note r-up js-reveal" style="--d:.46s"><b>Free</b> · no ads · your tests stay yours</p>
+                <p class="hero-note r-up js-reveal" style="--d:.46s"><b>@Localizer["Landing_HeroNoteBold"]</b> @Localizer["Landing_HeroNoteRest"]</p>
             </div>
 
             <div class="hero-visual" aria-hidden="true">
                 <div class="stack" id="stack">
                     <div class="card card-1 r-up js-reveal" style="--d:.35s">
-                        <span class="card-tag">Tonight's pick</span>
+                        <span class="card-tag">@Localizer["Landing_Card1Tag"]</span>
                         <div class="card-head">
                             <span class="card-title">Algebra II — Quadratics</span>
-                            <span class="card-score" style="color:var(--mint)">34 / 40 pts</span>
+                            <span class="card-score" style="color:var(--mint)">34 / 40 @Localizer["Common_Points"]</span>
                         </div>
-                        <p class="card-meta">Math · in 2 days</p>
-                        <p class="card-because"><b>Because:</b> you have low understanding, the test has very high volume, it's in 2 days.</p>
+                        <p class="card-meta">@Localizer["Demo_Math"] · @Localizer["Common_InDaysFmt", 2]</p>
+                        <p class="card-because"><b>@Localizer["Landing_Because"]</b> @Localizer["Landing_Card1Because"]</p>
                         <div class="card-bar"><i class="js-bar is-mint" data-w="85"></i></div>
                     </div>
                     <div class="card card-2 r-up js-reveal" style="--d:.48s">
                         <div class="card-head">
                             <span class="card-title">Vocabulaire — Unité 7</span>
-                            <span class="card-score">26 / 40 pts</span>
+                            <span class="card-score">26 / 40 @Localizer["Common_Points"]</span>
                         </div>
-                        <p class="card-meta">French · in 5 days</p>
-                        <p class="card-because"><b>Because:</b> medium understanding, high volume, your avg in French is 4.1.</p>
+                        <p class="card-meta">@Localizer["Demo_French"] · @Localizer["Common_InDaysFmt", 5]</p>
+                        <p class="card-because"><b>@Localizer["Landing_Because"]</b> @Localizer["Landing_Card2Because"]</p>
                         <div class="card-bar"><i class="js-bar" data-w="65"></i></div>
                     </div>
                     <div class="card card-3 r-up js-reveal" style="--d:.61s">
                         <div class="card-head">
                             <span class="card-title">Stoichiometry basics</span>
-                            <span class="card-score">19 / 40 pts</span>
+                            <span class="card-score">19 / 40 @Localizer["Common_Points"]</span>
                         </div>
-                        <p class="card-meta">Chemistry · in 9 days</p>
-                        <p class="card-because"><b>Because:</b> average understanding, medium volume, it's in 9 days.</p>
+                        <p class="card-meta">@Localizer["Demo_Chemistry"] · @Localizer["Common_InDaysFmt", 9]</p>
+                        <p class="card-because"><b>@Localizer["Landing_Because"]</b> @Localizer["Landing_Card3Because"]</p>
                         <div class="card-bar"><i class="js-bar" data-w="48"></i></div>
                     </div>
                 </div>
@@ -84,20 +84,20 @@
     <div class="marquee" aria-hidden="true">
         <div class="marquee-track">
             <span class="marquee-chunk">
-                <b>Math</b>&nbsp;· in 2 days ·&nbsp;<span class="pts">34 pts</span><em>✱</em>
-                <b>French</b>&nbsp;· in 5 days ·&nbsp;<span class="pts">26 pts</span><em>✱</em>
-                <b>Chemistry</b>&nbsp;· in 9 days ·&nbsp;<span class="pts">19 pts</span><em>✱</em>
-                <b>German</b>&nbsp;· in 12 days ·&nbsp;<span class="pts">14 pts</span><em>✱</em>
-                <b>English</b>&nbsp;· in 21 days ·&nbsp;<span class="pts">8 pts</span><em>✱</em>
-                <b>The highest score studies first</b><em>✱</em>
+                <b>@Localizer["Demo_Math"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 2] ·&nbsp;<span class="pts">34 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_French"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 5] ·&nbsp;<span class="pts">26 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_Chemistry"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 9] ·&nbsp;<span class="pts">19 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_German"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 12] ·&nbsp;<span class="pts">14 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_English"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 21] ·&nbsp;<span class="pts">8 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Landing_HighestStudiesFirst"]</b><em>✱</em>
             </span>
             <span class="marquee-chunk">
-                <b>Math</b>&nbsp;· in 2 days ·&nbsp;<span class="pts">34 pts</span><em>✱</em>
-                <b>French</b>&nbsp;· in 5 days ·&nbsp;<span class="pts">26 pts</span><em>✱</em>
-                <b>Chemistry</b>&nbsp;· in 9 days ·&nbsp;<span class="pts">19 pts</span><em>✱</em>
-                <b>German</b>&nbsp;· in 12 days ·&nbsp;<span class="pts">14 pts</span><em>✱</em>
-                <b>English</b>&nbsp;· in 21 days ·&nbsp;<span class="pts">8 pts</span><em>✱</em>
-                <b>The highest score studies first</b><em>✱</em>
+                <b>@Localizer["Demo_Math"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 2] ·&nbsp;<span class="pts">34 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_French"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 5] ·&nbsp;<span class="pts">26 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_Chemistry"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 9] ·&nbsp;<span class="pts">19 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_German"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 12] ·&nbsp;<span class="pts">14 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Demo_English"]</b>&nbsp;· @Localizer["Common_InDaysFmt", 21] ·&nbsp;<span class="pts">8 @Localizer["Common_Points"]</span><em>✱</em>
+                <b>@Localizer["Landing_HighestStudiesFirst"]</b><em>✱</em>
             </span>
         </div>
     </div>
@@ -107,53 +107,51 @@
         <div class="container ledger-wrap">
             <span class="ledger-watermark" aria-hidden="true">40</span>
             <div class="section-head">
-                <p class="eyebrow r-up js-reveal">The engine</p>
-                <h2 class="r-up js-reveal" style="--d:.08s">Your tests, <em>graded.</em></h2>
+                <p class="eyebrow r-up js-reveal">@Localizer["Landing_RubricEyebrow"]</p>
+                <h2 class="r-up js-reveal" style="--d:.08s">@Localizer["Landing_RubricTitlePre"]<em>@Localizer["Landing_RubricTitleEm"]</em></h2>
                 <p class="sub r-up js-reveal" style="--d:.16s">
-                    School grades you all year. WSIST turns the table — every upcoming test
-                    earns a priority score out of 40, built from four factors. No vibes,
-                    no guilt. Just arithmetic.
+                    @Localizer["Landing_RubricSub"]
                 </p>
             </div>
 
             <div class="ledger">
                 <div class="lrow r-up js-reveal">
                     <div class="lrow-name">
-                        <h3>Urgency</h3>
-                        <p>Tomorrow beats next month. Days left set the clock.</p>
+                        <h3>@Localizer["Score_Urgency"]</h3>
+                        <p>@Localizer["Landing_UrgencyDesc"]</p>
                     </div>
                     <p class="lrow-detail">≤1d +10&ensp;·&ensp;≤2d +8&ensp;·&ensp;≤7d +6&ensp;·&ensp;≤14d +4&ensp;·&ensp;≤30d +2</p>
-                    <div class="lrow-pts"><span class="num">+10</span><span class="lbl">pts max</span></div>
+                    <div class="lrow-pts"><span class="num">+10</span><span class="lbl">@Localizer["Landing_PtsMax"]</span></div>
                 </div>
 
                 <div class="lrow r-up js-reveal" style="--d:.07s">
                     <div class="lrow-name">
-                        <h3>Volume</h3>
-                        <p>Three chapters outweigh one worksheet.</p>
+                        <h3>@Localizer["Score_Volume"]</h3>
+                        <p>@Localizer["Landing_VolumeDesc"]</p>
                     </div>
-                    <p class="lrow-detail">very low +2&ensp;→&ensp;very high +12</p>
-                    <div class="lrow-pts"><span class="num">+12</span><span class="lbl">pts max</span></div>
+                    <p class="lrow-detail">@Localizer["Landing_VolumeDetail"]</p>
+                    <div class="lrow-pts"><span class="num">+12</span><span class="lbl">@Localizer["Landing_PtsMax"]</span></div>
                 </div>
 
                 <div class="lrow r-up js-reveal" style="--d:.14s">
                     <div class="lrow-name">
-                        <h3>Understanding</h3>
-                        <p>The less it clicks, the higher it climbs.</p>
+                        <h3>@Localizer["Score_Understanding"]</h3>
+                        <p>@Localizer["Landing_UnderstandingDesc"]</p>
                     </div>
-                    <p class="lrow-detail">very high +2&ensp;→&ensp;very low +12</p>
-                    <div class="lrow-pts"><span class="num">+12</span><span class="lbl">pts max</span></div>
+                    <p class="lrow-detail">@Localizer["Landing_UnderstandingDetail"]</p>
+                    <div class="lrow-pts"><span class="num">+12</span><span class="lbl">@Localizer["Landing_PtsMax"]</span></div>
                 </div>
 
                 <div class="lrow r-up js-reveal" style="--d:.21s">
                     <div class="lrow-name">
-                        <h3>Grade pull</h3>
-                        <p>Subjects where your average slips get a push.</p>
+                        <h3>@Localizer["Landing_GradePullName"]</h3>
+                        <p>@Localizer["Landing_GradePullDesc"]</p>
                     </div>
                     <p class="lrow-detail">Ø ≥5 +2&ensp;·&ensp;Ø ≥4 +4&ensp;·&ensp;Ø &lt;4 +6</p>
-                    <div class="lrow-pts"><span class="num">+6</span><span class="lbl">pts max</span></div>
+                    <div class="lrow-pts"><span class="num">+6</span><span class="lbl">@Localizer["Landing_PtsMax"]</span></div>
                 </div>
 
-                <p class="ledger-sum r-up js-reveal" style="--d:.28s">= <b>&nbsp;40 pts</b>&nbsp;— the highest score studies first</p>
+                <p class="ledger-sum r-up js-reveal" style="--d:.28s">= <b>&nbsp;40 @Localizer["Common_Points"]</b>&nbsp;— @Localizer["Landing_HighestStudiesFirst"]</p>
             </div>
         </div>
     </section>
@@ -162,11 +160,10 @@
     <section class="section" id="try" style="padding-top:0">
         <div class="container">
             <div class="section-head">
-                <p class="eyebrow r-up js-reveal">No-signup demo</p>
-                <h2 class="r-up js-reveal" style="--d:.08s">Run the <em>real</em> algorithm.</h2>
+                <p class="eyebrow r-up js-reveal">@Localizer["Landing_PlayEyebrow"]</p>
+                <h2 class="r-up js-reveal" style="--d:.08s">@Localizer["Landing_PlayTitlePre"]<em>@Localizer["Landing_PlayTitleEm"]</em>@Localizer["Landing_PlayTitlePost"]</h2>
                 <p class="sub r-up js-reveal" style="--d:.16s">
-                    These sliders feed the same scoring rules that run in production at
-                    wsist.forch.me. Move them and watch a test climb your list.
+                    @Localizer["Landing_PlaySub"]
                 </p>
             </div>
 
@@ -174,58 +171,58 @@
                 <div class="controls r-up js-reveal">
                     <div class="ctl">
                         <div class="ctl-head">
-                            <label for="in-days">Days until the test</label>
-                            <output id="out-days" for="in-days">in 2 days</output>
+                            <label for="in-days">@Localizer["Landing_CtlDays"]</label>
+                            <output id="out-days" for="in-days">@Localizer["Common_InDaysFmt", 2]</output>
                         </div>
                         <input type="range" id="in-days" min="0" max="35" step="1" value="2"/>
-                        <div class="ctl-scale"><span>today</span><span>5 weeks out</span></div>
+                        <div class="ctl-scale"><span>@Localizer["Landing_ScaleToday"]</span><span>@Localizer["Landing_Scale5Weeks"]</span></div>
                     </div>
 
                     <div class="ctl">
                         <div class="ctl-head">
-                            <label for="in-vol">Test volume</label>
-                            <output id="out-vol" for="in-vol">High</output>
+                            <label for="in-vol">@Localizer["Landing_CtlVol"]</label>
+                            <output id="out-vol" for="in-vol">@Localizer["Level_High"]</output>
                         </div>
                         <input type="range" id="in-vol" min="0" max="5" step="1" value="4"/>
-                        <div class="ctl-scale"><span>one worksheet</span><span>three chapters</span></div>
+                        <div class="ctl-scale"><span>@Localizer["Landing_ScaleWorksheet"]</span><span>@Localizer["Landing_ScaleChapters"]</span></div>
                     </div>
 
                     <div class="ctl">
                         <div class="ctl-head">
-                            <label for="in-und">Your understanding</label>
-                            <output id="out-und" for="in-und">Low</output>
+                            <label for="in-und">@Localizer["Landing_CtlUnd"]</label>
+                            <output id="out-und" for="in-und">@Localizer["Level_Low"]</output>
                         </div>
                         <input type="range" id="in-und" min="0" max="5" step="1" value="1"/>
-                        <div class="ctl-scale"><span>what even is this</span><span>could teach it</span></div>
+                        <div class="ctl-scale"><span>@Localizer["Landing_ScaleWhatEven"]</span><span>@Localizer["Landing_ScaleCouldTeach"]</span></div>
                     </div>
 
                     <div class="ctl">
                         <div class="ctl-head">
-                            <label for="in-avg">Your average in this subject</label>
+                            <label for="in-avg">@Localizer["Landing_CtlAvg"]</label>
                             <output id="out-avg" for="in-avg">Ø 4.2</output>
                         </div>
                         <input type="range" id="in-avg" min="1" max="6" step="0.1" value="4.2"/>
-                        <div class="ctl-scale"><span>1.0</span><span>6.0 — Swiss scale</span></div>
+                        <div class="ctl-scale"><span>1.0</span><span>@Localizer["Landing_Scale6Swiss"]</span></div>
                     </div>
                 </div>
 
                 <div class="result r-up js-reveal" style="--d:.12s" aria-live="polite">
-                    <p class="result-eyebrow">Priority score</p>
+                    <p class="result-eyebrow">@Localizer["Landing_ResultEyebrow"]</p>
                     <div class="result-score">
                         <span class="score-num" id="score-num">32</span>
-                        <span class="score-denom">/ 40 pts</span>
+                        <span class="score-denom">@Localizer["Landing_ResultDenom"]</span>
                     </div>
                     <div class="stackbar" aria-hidden="true">
                         <i class="seg-u" id="seg-u"></i><i class="seg-v" id="seg-v"></i><i class="seg-n" id="seg-n"></i><i class="seg-g" id="seg-g"></i>
                     </div>
                     <div class="chips" aria-hidden="true">
-                        <div class="chip"><span class="v" id="chip-u">+8</span><span class="k" style="--sw:var(--accent)">urgency</span></div>
-                        <div class="chip"><span class="v" id="chip-v">+10</span><span class="k" style="--sw:rgba(245,179,66,.68)">volume</span></div>
-                        <div class="chip"><span class="v" id="chip-n">+10</span><span class="k" style="--sw:rgba(245,179,66,.44)">understanding</span></div>
-                        <div class="chip"><span class="v" id="chip-g">+4</span><span class="k" style="--sw:rgba(245,179,66,.24)">grade pull</span></div>
+                        <div class="chip"><span class="v" id="chip-u">+8</span><span class="k" style="--sw:var(--accent)">@Localizer["Landing_ChipUrgency"]</span></div>
+                        <div class="chip"><span class="v" id="chip-v">+10</span><span class="k" style="--sw:rgba(245,179,66,.68)">@Localizer["Landing_ChipVolume"]</span></div>
+                        <div class="chip"><span class="v" id="chip-n">+10</span><span class="k" style="--sw:rgba(245,179,66,.44)">@Localizer["Landing_ChipUnderstanding"]</span></div>
+                        <div class="chip"><span class="v" id="chip-g">+4</span><span class="k" style="--sw:rgba(245,179,66,.24)">@Localizer["Landing_ChipGradePull"]</span></div>
                     </div>
-                    <p class="verdict" id="verdict">Drop everything — this is tonight.</p>
-                    <p class="result-foot">Same maths as the production engine</p>
+                    <p class="verdict" id="verdict">@Localizer["Landing_VerdictInitial"]</p>
+                    <p class="result-foot">@Localizer["Landing_ResultFoot"]</p>
                 </div>
             </div>
         </div>
@@ -235,23 +232,23 @@
     <section class="section" id="how" style="padding-top:0">
         <div class="container">
             <div class="section-head">
-                <p class="eyebrow r-up js-reveal">The routine</p>
-                <h2 class="r-up js-reveal" style="--d:.08s">Twenty seconds in, <em>one answer</em> out.</h2>
+                <p class="eyebrow r-up js-reveal">@Localizer["Landing_HowEyebrow"]</p>
+                <h2 class="r-up js-reveal" style="--d:.08s">@Localizer["Landing_HowTitlePre"]<em>@Localizer["Landing_HowTitleEm"]</em>@Localizer["Landing_HowTitlePost"]</h2>
             </div>
 
             <div class="steps">
                 <div class="step r-up js-reveal">
                     <span class="step-num" aria-hidden="true">01</span>
                     <div class="step-body">
-                        <h3>Add the test.</h3>
-                        <p>Title, subject, date, how big it is, how well you get it. Twenty seconds, once per test.</p>
+                        <h3>@Localizer["Landing_Step1Title"]</h3>
+                        <p>@Localizer["Landing_Step1Desc"]</p>
                     </div>
                     <div class="mock step-mock" aria-hidden="true">
-                        <p class="mock-label">Test title</p>
+                        <p class="mock-label">@Localizer["Landing_MockTestTitle"]</p>
                         <div class="mock-field">Algebra II — Quadratics</div>
-                        <p class="mock-label">Subject &nbsp;·&nbsp; Due date</p>
+                        <p class="mock-label">@Localizer["Landing_MockSubjectDue"]</p>
                         <div class="mock-row">
-                            <div class="mock-field" style="flex:1">Math ▾</div>
+                            <div class="mock-field" style="flex:1">@Localizer["Demo_Math"] ▾</div>
                             <div class="mock-field" style="flex:1">12.06.2026</div>
                         </div>
                     </div>
@@ -260,14 +257,14 @@
                 <div class="step r-up js-reveal">
                     <span class="step-num" aria-hidden="true">02</span>
                     <div class="step-body">
-                        <h3>Say how much time you have.</h3>
-                        <p>One input. “How many hours can you study today?” is the only question WSIST ever asks you back.</p>
+                        <h3>@Localizer["Landing_Step2Title"]</h3>
+                        <p>@Localizer["Landing_Step2Desc"]</p>
                     </div>
                     <div class="mock step-mock" aria-hidden="true">
-                        <p class="mock-label">How many hours can you study today?</p>
+                        <p class="mock-label">@Localizer["Landing_MockHours"]</p>
                         <div class="mock-row">
                             <div class="mock-field" style="width:90px;text-align:center">2.5</div>
-                            <span class="mock-btn">Calculate</span>
+                            <span class="mock-btn">@Localizer["Study_Calculate"]</span>
                         </div>
                     </div>
                 </div>
@@ -275,13 +272,13 @@
                 <div class="step r-up js-reveal">
                     <span class="step-num" aria-hidden="true">03</span>
                     <div class="step-body">
-                        <h3>Study the top of the list.</h3>
-                        <p>Every test ranked out of 40, with the reasons spelled out — so you trust the order instead of second-guessing it.</p>
+                        <h3>@Localizer["Landing_Step3Title"]</h3>
+                        <p>@Localizer["Landing_Step3Desc"]</p>
                     </div>
                     <div class="mock step-mock" aria-hidden="true">
-                        <div class="mock-rank"><span class="pos">1</span><span class="t">Algebra II</span><span class="s">34 pts</span><span class="b"><i style="width:85%"></i></span></div>
-                        <div class="mock-rank"><span class="pos">2</span><span class="t">Vocabulaire U7</span><span class="s">26 pts</span><span class="b"><i style="width:65%"></i></span></div>
-                        <div class="mock-rank"><span class="pos">3</span><span class="t">Stoichiometry</span><span class="s">19 pts</span><span class="b"><i style="width:48%"></i></span></div>
+                        <div class="mock-rank"><span class="pos">1</span><span class="t">Algebra II</span><span class="s">34 @Localizer["Common_Points"]</span><span class="b"><i style="width:85%"></i></span></div>
+                        <div class="mock-rank"><span class="pos">2</span><span class="t">Vocabulaire U7</span><span class="s">26 @Localizer["Common_Points"]</span><span class="b"><i style="width:65%"></i></span></div>
+                        <div class="mock-rank"><span class="pos">3</span><span class="t">Stoichiometry</span><span class="s">19 @Localizer["Common_Points"]</span><span class="b"><i style="width:48%"></i></span></div>
                     </div>
                 </div>
             </div>
@@ -292,33 +289,33 @@
     <section class="section" id="features" style="padding-top:0">
         <div class="container">
             <div class="section-head">
-                <p class="eyebrow r-up js-reveal">Also in the box</p>
-                <h2 class="r-up js-reveal" style="--d:.08s">The quiet parts.</h2>
+                <p class="eyebrow r-up js-reveal">@Localizer["Landing_FeatEyebrow"]</p>
+                <h2 class="r-up js-reveal" style="--d:.08s">@Localizer["Landing_FeatTitle"]</h2>
             </div>
             <div class="feat-grid">
                 <div class="feat r-up js-reveal">
-                    <h3>Grade overview per subject</h3>
-                    <p>Your averages on the dashboard, always current — so a slipping subject shows up before the report card does.</p>
+                    <h3>@Localizer["Landing_Feat1Title"]</h3>
+                    <p>@Localizer["Landing_Feat1Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.06s">
-                    <h3>Your subjects, not a preset</h3>
-                    <p>Add the subjects your school actually teaches. Wirtschaft, Werkstatt, whatever — WSIST doesn't care, it just scores.</p>
+                    <h3>@Localizer["Landing_Feat2Title"]</h3>
+                    <p>@Localizer["Landing_Feat2Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.12s">
-                    <h3>Every rank explains itself</h3>
-                    <p>Tap any card for its score breakdown. You always see why a test sits where it sits.</p>
+                    <h3>@Localizer["Landing_Feat3Title"]</h3>
+                    <p>@Localizer["Landing_Feat3Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.18s">
-                    <h3>Sign in with Google</h3>
-                    <p>Nothing new to remember. Your school account works fine.</p>
+                    <h3>@Localizer["Landing_Feat4Title"]</h3>
+                    <p>@Localizer["Landing_Feat4Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.24s">
-                    <h3>Private by default</h3>
-                    <p>Your tests and grades are visible to you alone, and you can delete them anytime. No ads, ever.</p>
+                    <h3>@Localizer["Landing_Feat5Title"]</h3>
+                    <p>@Localizer["Landing_Feat5Desc"]</p>
                 </div>
                 <div class="feat r-up js-reveal" style="--d:.3s">
-                    <h3>“WSIST sagt” <span class="soon">Soon</span></h3>
-                    <p>A daily study briefing in Swiss German, plus an Android app. In the works between exam weeks.</p>
+                    <h3>“WSIST sagt” <span class="soon">@Localizer["Landing_Soon"]</span></h3>
+                    <p>@Localizer["Landing_Feat6Desc"]</p>
                 </div>
             </div>
         </div>
@@ -328,7 +325,7 @@
     <section class="section manifesto">
         <div class="container manifesto">
             <blockquote class="r-up js-reveal">
-                Built between apprenticeship shifts and exam weeks — by a student who <b>needed it to exist.</b>
+                @Localizer["Landing_ManifestoPre"]<b>@Localizer["Landing_ManifestoBold"]</b>
             </blockquote>
             <cite class="r-up js-reveal" style="--d:.12s">Tim · Informatik-Lehrling · Zürich</cite>
         </div>
@@ -337,13 +334,13 @@
     <!-- ============ FINAL CTA ============ -->
     <section class="section cta">
         <div class="container">
-            <h2 class="r-up js-reveal">Your next test is coming <em>either way.</em></h2>
+            <h2 class="r-up js-reveal">@Localizer["Landing_CtaTitlePre"]<em>@Localizer["Landing_CtaTitleEm"]</em></h2>
             <div class="cta-row r-up js-reveal" style="--d:.1s">
                 <a class="btn btn-primary" href="/login" data-enhance-nav="false">
                     <svg class="g-mark" viewBox="0 0 48 48" aria-hidden="true"><path fill="#FFC107" d="M43.6 20.1H42V20H24v8h11.3C33.7 32.7 29.2 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 13 4 4 13 4 24s9 20 20 20 20-9 20-20c0-1.3-.1-2.6-.4-3.9z"/><path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 15.1 19 12 24 12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 16.3 4 9.7 8.3 6.3 14.7z"/><path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.3C29.2 35.1 26.7 36 24 36c-5.2 0-9.6-3.3-11.3-8l-6.5 5C9.5 39.6 16.2 44 24 44z"/><path fill="#1976D2" d="M43.6 20.1H42V20H24v8h11.3c-.8 2.2-2.2 4.2-4.1 5.5l6.2 5.3C37 39.2 44 34 44 24c0-1.3-.1-2.6-.4-3.9z"/></svg>
-                    Continue with Google
+                    @Localizer["Common_ContinueWithGoogle"]
                 </a>
-                <span class="cta-small">Free · works in any browser</span>
+                <span class="cta-small">@Localizer["Landing_CtaSmall"]</span>
             </div>
         </div>
     </section>
@@ -351,13 +348,13 @@
     <!-- ============ FOOTER ============ -->
     <footer>
         <div class="container foot">
-            <span class="wm">WSIST<i>.</i> — what should I study today</span>
+            <span class="wm">WSIST<i>.</i> — @Localizer["Landing_LogoTag"]</span>
             <div class="foot-links">
                 <a href="https://wsist.forch.me">wsist.forch.me</a>
-                <a href="/privacy">Privacy</a>
-                <a href="/terms">Terms</a>
+                <a href="/privacy">@Localizer["Legal_Privacy"]</a>
+                <a href="/terms">@Localizer["Legal_Terms"]</a>
             </div>
-            <span>Made in Zürich · © 2026 Tim Hug</span>
+            <span>@Localizer["Landing_FooterMade"]</span>
         </div>
     </footer>
 </div>

--- a/WSIST/WSIST.Web/Components/Pages/NotFound.razor
+++ b/WSIST/WSIST.Web/Components/Pages/NotFound.razor
@@ -1,13 +1,14 @@
 @page "/not-found"
 @layout EmptyLayout
 @using WSIST.Web.Components.Layout
-<PageTitle>Page not found – WSIST</PageTitle>
+@inject IStringLocalizer<SharedResource> Localizer
+<PageTitle>@Localizer["NotFound_Title"] – WSIST</PageTitle>
 
 <div class="error-page">
     <div class="error-content">
         <span class="error-icon" aria-hidden="true">🔍</span>
-        <h1 class="error-title">Page not found</h1>
-        <p class="error-sub">The page you're looking for doesn't exist or has been moved.</p>
-        <a href="/" class="button-primary button-accent" data-enhance-nav="false">← Back to home</a>
+        <h1 class="error-title">@Localizer["NotFound_Title"]</h1>
+        <p class="error-sub">@Localizer["NotFound_Sub"]</p>
+        <a href="/" class="button-primary button-accent" data-enhance-nav="false">← @Localizer["Common_BackToHome"]</a>
     </div>
 </div>

--- a/WSIST/WSIST.Web/Components/Pages/Privacy.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Privacy.razor
@@ -1,7 +1,8 @@
 @page "/privacy"
 @layout EmptyLayout
 @using WSIST.Web.Components.Layout
-<PageTitle>Privacy Policy – WSIST</PageTitle>
+@inject IStringLocalizer<SharedResource> Localizer
+<PageTitle>@Localizer["Privacy_Title"] – WSIST</PageTitle>
 
 <div class="legal-page">
     <nav class="landing-nav">
@@ -9,75 +10,29 @@
             <img src="/logo.svg" width="32" height="32" alt="WSIST" />
             <span>WSIST</span>
         </div>
-        <a href="/login-page" class="landing-cta-sm" style="color: var(--text-secondary); text-decoration: none;">← Back</a>
+        <div class="landing-nav-actions">
+            <LanguageToggle />
+            <a href="/login-page" class="landing-cta-sm" style="color: var(--text-secondary); text-decoration: none;">← @Localizer["Common_Back"]</a>
+        </div>
     </nav>
 
     <div class="legal-content">
-        <h1>Privacy Policy</h1>
-        <p class="legal-meta">Last updated: @(new DateTime(2026, 6, 1).ToString("MMMM d, yyyy"))</p>
+        <h1>@Localizer["Privacy_Title"]</h1>
+        <p class="legal-meta">@Localizer["Legal_LastUpdated"] @(new DateTime(2026, 6, 1).ToString("MMMM d, yyyy"))</p>
 
-        <h2>1. Who we are</h2>
-        <p>WSIST ("What Should I Study Today") is a personal study planning application developed and operated by Tim Hug, based in Switzerland. This privacy policy explains what personal data we collect, how we use it, and what rights you have.</p>
-        <p>Contact: <a href="mailto:privacy@wsist.forch.me">privacy@wsist.forch.me</a></p>
-
-        <h2>2. Data we collect</h2>
-        <p>When you sign in with Google, we receive and store the following data from Google's OAuth service:</p>
-        <ul>
-            <li><strong>Email address</strong> — used to identify your account</li>
-            <li><strong>Display name</strong> — shown in the application</li>
-            <li><strong>Google user ID</strong> — used to link your Google account to your WSIST account</li>
-        </ul>
-        <p>We also store data you create while using the application:</p>
-        <ul>
-            <li>Test entries (title, subject, due date, volume, understanding level, grade)</li>
-            <li>Custom subjects you create</li>
-            <li>Your display name if you update it in settings</li>
-            <li>Your account creation timestamp</li>
-        </ul>
-        <p>We do not collect location data, device identifiers, or any data beyond what is listed above.</p>
-
-        <h2>3. How we use your data</h2>
-        <p>Your data is used solely to provide the WSIST service:</p>
-        <ul>
-            <li>Authenticating you when you log in</li>
-            <li>Storing and displaying your test entries</li>
-            <li>Calculating study recommendations and priority scores</li>
-            <li>Showing your grade overview</li>
-        </ul>
-        <p>We do not sell your data, share it with advertisers, or use it for any purpose other than providing the service.</p>
-
-        <h2>4. Legal basis for processing (GDPR / Swiss nDSG)</h2>
-        <p>We process your personal data on the basis of <strong>contract performance</strong> (Art. 6(1)(b) GDPR) — processing is necessary to provide the service you have requested. By creating an account and using WSIST, you enter into a contract with us for the provision of the application.</p>
-
-        <h2>5. Third-party services</h2>
-        <p><strong>Google OAuth:</strong> Login is handled via Google's OAuth 2.0 service. When you authenticate, Google shares your profile data with us as described in section 2. Google's own privacy policy applies to the authentication process: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">policies.google.com/privacy</a>.</p>
-        <p><strong>Railway:</strong> The application is hosted on Railway (railway.app). Your data is stored on a MySQL database on their infrastructure. Railway's privacy policy applies to hosting: <a href="https://railway.app/legal/privacy" target="_blank" rel="noopener">railway.app/legal/privacy</a>.</p>
-        <p><strong>Cloudflare:</strong> The application is served behind Cloudflare's CDN. Cloudflare may process connection metadata (IP address, request headers) as part of its service. Cloudflare's privacy policy: <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">cloudflare.com/privacypolicy</a>.</p>
-
-        <h2>6. Data retention</h2>
-        <p>Your data is retained for as long as you have an active account. If you wish to delete your account and all associated data, contact us at <a href="mailto:privacy@wsist.forch.me">privacy@wsist.forch.me</a> and we will delete it within 30 days.</p>
-
-        <h2>7. Your rights</h2>
-        <p>Under the GDPR and Swiss nDSG, you have the following rights:</p>
-        <ul>
-            <li><strong>Access:</strong> You can request a copy of all personal data we hold about you.</li>
-            <li><strong>Rectification:</strong> You can correct inaccurate data via the Settings page or by contacting us.</li>
-            <li><strong>Erasure:</strong> You can request deletion of your account and all associated data.</li>
-            <li><strong>Portability:</strong> You can request your data in a machine-readable format.</li>
-            <li><strong>Objection:</strong> You can object to processing in certain circumstances.</li>
-        </ul>
-        <p>To exercise any of these rights, contact us at <a href="mailto:privacy@wsist.forch.me">privacy@wsist.forch.me</a>. We will respond within 30 days.</p>
-
-        <h2>8. Cookies and sessions</h2>
-        <p>WSIST uses a single authentication cookie (`.AspNetCore.Cookies`) to maintain your login session. This cookie is strictly necessary for the application to function and does not track you across other websites. No analytics, advertising, or third-party tracking cookies are used.</p>
-
-        <h2>9. Security</h2>
-        <p>Your data is transmitted over HTTPS. Passwords are never stored — authentication is handled entirely by Google. Database access is restricted to the application only.</p>
-
-        <h2>10. Changes to this policy</h2>
-        <p>If we make material changes to this policy, we will update the "last updated" date at the top of this page. Continued use of WSIST after changes constitutes acceptance of the updated policy.</p>
-
-        <h2>11. Contact</h2>
-        <p>Questions about this privacy policy? Contact us at <a href="mailto:privacy@wsist.forch.me">privacy@wsist.forch.me</a>.</p>
+        @* Section bodies are static, developer-authored HTML stored in the
+           resource files; rendered as markup so inline emphasis and links
+           survive translation. No user input is involved. *@
+        @((MarkupString)Localizer["Privacy_Sec1"].Value)
+        @((MarkupString)Localizer["Privacy_Sec2"].Value)
+        @((MarkupString)Localizer["Privacy_Sec3"].Value)
+        @((MarkupString)Localizer["Privacy_Sec4"].Value)
+        @((MarkupString)Localizer["Privacy_Sec5"].Value)
+        @((MarkupString)Localizer["Privacy_Sec6"].Value)
+        @((MarkupString)Localizer["Privacy_Sec7"].Value)
+        @((MarkupString)Localizer["Privacy_Sec8"].Value)
+        @((MarkupString)Localizer["Privacy_Sec9"].Value)
+        @((MarkupString)Localizer["Privacy_Sec10"].Value)
+        @((MarkupString)Localizer["Privacy_Sec11"].Value)
     </div>
 </div>

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor
@@ -79,6 +79,24 @@
             </div>
 
             <div class="settings-block">
+                <p class="settings-block-label">Data</p>
+                <div class="settings-card">
+                    <div class="settings-row settings-row-last">
+                        <div>
+                            <span class="settings-row-key">Export my data</span>
+                            <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
+                                Download all your tests and grades, including past graded ones.
+                            </p>
+                        </div>
+                        <div class="settings-inline">
+                            <a href="/api/export?format=csv" class="button-primary button-accent" data-enhance-nav="false" download>CSV</a>
+                            <a href="/api/export?format=json" class="button-primary" data-enhance-nav="false" download>JSON</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="settings-block">
                 <p class="settings-block-label">Account</p>
                 <div class="settings-card">
                     @if (!showDeleteConfirm)

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor
@@ -5,10 +5,10 @@
 
 <div class="page">
     <div class="top-row">
-        <div class="title nav-brand">
+        <a href="/" class="title nav-brand" data-enhance-nav="false">
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
-        </div>
+        </a>
         <LanguageToggle />
         <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
         <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor
@@ -1,7 +1,7 @@
 @page "/settings"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @inherits AuthenticatedComponentBase
-<PageTitle>WSIST — Settings</PageTitle>
+<PageTitle>WSIST — @localizer["Settings_Title"]</PageTitle>
 
 <div class="page">
     <div class="top-row">
@@ -9,27 +9,28 @@
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
         </div>
-        <a href="/" class="button-primary" data-enhance-nav="false">← Back</a>
-        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
+        <LanguageToggle />
+        <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
+        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>
     </div>
 
     <div class="content px-4">
         <div class="settings-page-header">
-            <h1>Settings</h1>
-            <p>Manage your profile and subjects.</p>
+            <h1>@localizer["Settings_Title"]</h1>
+            <p>@localizer["Settings_Subtitle"]</p>
         </div>
 
         @if (currentUser is not null)
         {
             <div class="settings-block">
-                <p class="settings-block-label">Profile</p>
+                <p class="settings-block-label">@localizer["Settings_Profile"]</p>
                 <div class="settings-card">
                     <div class="settings-row">
-                        <span class="settings-row-key">Display name</span>
+                        <span class="settings-row-key">@localizer["Settings_DisplayName"]</span>
                         <div class="settings-row-value">
                             <div class="settings-inline">
                                 <input type="text" class="settings-input" @bind="editedDisplayName" @bind:event="oninput" maxlength="100"/>
-                                <button class="button-primary button-accent" @onclick="SaveDisplayName">Save</button>
+                                <button class="button-primary button-accent" @onclick="SaveDisplayName">@localizer["Common_Save"]</button>
                             </div>
                             @if (saveMessage is not null)
                             {
@@ -38,18 +39,18 @@
                         </div>
                     </div>
                     <div class="settings-row">
-                        <span class="settings-row-key">Email</span>
+                        <span class="settings-row-key">@localizer["Settings_Email"]</span>
                         <span class="settings-row-val">@currentUser.Email</span>
                     </div>
                     <div class="settings-row settings-row-last">
-                        <span class="settings-row-key">Member since</span>
+                        <span class="settings-row-key">@localizer["Settings_MemberSince"]</span>
                         <span class="settings-row-val">@currentUser.CreatedAt.ToString("MMMM yyyy")</span>
                     </div>
                 </div>
             </div>
 
             <div class="settings-block">
-                <p class="settings-block-label">Subjects</p>
+                <p class="settings-block-label">@localizer["Settings_Subjects"]</p>
                 <div class="settings-card">
                     @foreach (var subject in subjects)
                     {
@@ -57,18 +58,18 @@
                             <span class="subject-name">@subject.Name</span>
                             @if (subject.IsSystem)
                             {
-                                <span class="subject-badge">system</span>
+                                <span class="subject-badge">@localizer["Settings_SystemBadge"]</span>
                             }
                             else
                             {
-                                <button class="button-primary button-danger" style="padding: 4px 10px; font-size: 12px;" @onclick="() => DeleteSubject(subject.Id)">Remove</button>
+                                <button class="button-primary button-danger" style="padding: 4px 10px; font-size: 12px;" @onclick="() => DeleteSubject(subject.Id)">@localizer["Common_Remove"]</button>
                             }
                         </div>
                     }
                     <div class="settings-add-subject">
                         <div class="settings-inline">
-                            <input type="text" class="settings-input" placeholder="New subject name" @bind="newSubjectName" @bind:event="oninput" maxlength="100"/>
-                            <button class="button-primary button-accent" @onclick="AddSubject">Add</button>
+                            <input type="text" class="settings-input" placeholder="@localizer["Settings_NewSubjectPlaceholder"]" @bind="newSubjectName" @bind:event="oninput" maxlength="100"/>
+                            <button class="button-primary button-accent" @onclick="AddSubject">@localizer["Common_Add"]</button>
                         </div>
                         @if (subjectError is not null)
                         {
@@ -79,13 +80,13 @@
             </div>
 
             <div class="settings-block">
-                <p class="settings-block-label">Data</p>
+                <p class="settings-block-label">@localizer["Settings_Data"]</p>
                 <div class="settings-card">
                     <div class="settings-row settings-row-last">
                         <div>
-                            <span class="settings-row-key">Export my data</span>
+                            <span class="settings-row-key">@localizer["Settings_ExportTitle"]</span>
                             <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
-                                Download all your tests and grades, including past graded ones.
+                                @localizer["Settings_ExportSub"]
                             </p>
                         </div>
                         <div class="settings-inline">
@@ -97,50 +98,52 @@
             </div>
 
             <div class="settings-block">
-                <p class="settings-block-label">Feedback</p>
+                <p class="settings-block-label">@localizer["Settings_Feedback"]</p>
                 <div class="settings-card">
                     <div class="settings-row settings-row-last">
                         <div>
-                            <span class="settings-row-key">Feedback &amp; feature requests</span>
+                            <span class="settings-row-key">@localizer["Settings_FeedbackTitle"]</span>
                             <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
-                                Report a bug or suggest an improvement.
+                                @localizer["Settings_FeedbackSub"]
                             </p>
                         </div>
-                        <a href="/feedback" class="button-primary button-accent" data-enhance-nav="false">Open</a>
+                        <a href="/feedback" class="button-primary button-accent" data-enhance-nav="false">@localizer["Common_Open"]</a>
                     </div>
                 </div>
             </div>
 
             <div class="settings-block">
-                <p class="settings-block-label">Account</p>
+                <p class="settings-block-label">@localizer["Settings_Account"]</p>
                 <div class="settings-card">
                     @if (!showDeleteConfirm)
                     {
                         <div class="settings-row settings-row-last">
                             <div>
-                                <span class="settings-row-key">Delete account</span>
+                                <span class="settings-row-key">@localizer["Settings_DeleteAccount"]</span>
                                 <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
-                                    Permanently removes your account and all test data.
+                                    @localizer["Settings_DeleteAccountSub"]
                                 </p>
                             </div>
                             <button class="button-primary button-danger" @onclick="ShowDeleteConfirm">
-                                Delete account
+                                @localizer["Settings_DeleteAccount"]
                             </button>
                         </div>
                     }
                     else
                     {
                         <div class="delete-confirm-zone">
-                            <p class="delete-confirm-title">Are you sure?</p>
+                            <p class="delete-confirm-title">@localizer["Settings_AreYouSure"]</p>
                             <p class="delete-confirm-sub">
-                                This will permanently delete your account, all @allTests.Count test@(allTests.Count == 1 ? "" : "s"), and all custom subjects. This cannot be undone.
+                                @(allTests.Count == 1
+                                    ? localizer["Settings_DeleteConfirmOne"]
+                                    : localizer["Settings_DeleteConfirmFmt", allTests.Count])
                             </p>
                             <div class="delete-confirm-actions">
                                 <button class="button-primary" @onclick="CancelDelete" disabled="@isDeleting">
-                                    Cancel
+                                    @localizer["Common_Cancel"]
                                 </button>
                                 <button class="button-primary button-danger" @onclick="ConfirmDeleteAccount" disabled="@isDeleting">
-                                    @(isDeleting ? "Deleting…" : "Yes, delete everything")
+                                    @(isDeleting ? localizer["Settings_Deleting"] : localizer["Settings_DeleteEverything"])
                                 </button>
                             </div>
                         </div>

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor
@@ -97,6 +97,21 @@
             </div>
 
             <div class="settings-block">
+                <p class="settings-block-label">Feedback</p>
+                <div class="settings-card">
+                    <div class="settings-row settings-row-last">
+                        <div>
+                            <span class="settings-row-key">Feedback &amp; feature requests</span>
+                            <p style="font-size: 13px; color: var(--text-muted); margin-top: 3px;">
+                                Report a bug or suggest an improvement.
+                            </p>
+                        </div>
+                        <a href="/feedback" class="button-primary button-accent" data-enhance-nav="false">Open</a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="settings-block">
                 <p class="settings-block-label">Account</p>
                 <div class="settings-card">
                     @if (!showDeleteConfirm)

--- a/WSIST/WSIST.Web/Components/Pages/Settings.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Settings.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Localization;
 using WSIST.Engine;
 
 namespace WSIST.Web.Components.Pages;
@@ -7,7 +8,8 @@ namespace WSIST.Web.Components.Pages;
 public partial class Settings(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
-    NavigationManager navigation
+    NavigationManager navigation,
+    IStringLocalizer<SharedResource> localizer
 ) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private User? currentUser;
@@ -35,7 +37,7 @@ public partial class Settings(
             return;
         management.UpdateDisplayName(CurrentUserId, editedDisplayName);
         currentUser = management.GetUser(CurrentUserId);
-        saveMessage = "Saved.";
+        saveMessage = localizer["Settings_Saved"];
         StateHasChanged();
     }
 
@@ -51,12 +53,12 @@ public partial class Settings(
         }
         catch (ArgumentException)
         {
-            subjectError = "Subject name cannot be empty.";
+            subjectError = localizer["Subject_EmptyError"];
             return;
         }
         catch (SubjectAlreadyExistsException)
         {
-            subjectError = "A subject with that name already exists.";
+            subjectError = localizer["Subject_DuplicateError"];
             return;
         }
 
@@ -70,8 +72,7 @@ public partial class Settings(
         subjectError = null;
         if (!management.RemoveCustomSubject(subjectId, CurrentUserId))
         {
-            subjectError =
-                "Cannot delete a subject that still has tests. Delete or reassign those tests first.";
+            subjectError = localizer["Settings_SubjectInUseError"];
             StateHasChanged();
             return;
         }

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -10,32 +10,33 @@
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
         </div>
-        <a href="/" class="button-primary" data-enhance-nav="false">← Back</a>
-        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">Logout</a>
+        <LanguageToggle />
+        <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
+        <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>
     </div>
 
     <div class="content px-4">
         <div class="study-header">
-            <h1>What should I study?</h1>
-            <p>Tell us how much time you have — we'll figure out the rest.</p>
+            <h1>@localizer["Study_Title"]</h1>
+            <p>@localizer["Study_Subtitle"]</p>
         </div>
 
         <div class="study-mode-toggle">
             <button class="study-mode-btn @(!weeklyMode ? "active" : "")" @onclick="() => weeklyMode = false">
-                Today
+                @localizer["Study_Today"]
             </button>
             <button class="study-mode-btn @(weeklyMode ? "active" : "")" @onclick="() => weeklyMode = true">
-                This week
+                @localizer["Study_ThisWeek"]
             </button>
         </div>
 
         @if (!weeklyMode)
         {
         <div class="study-input-card">
-            <label class="study-input-label">Hours available today</label>
+            <label class="study-input-label">@localizer["Study_HoursToday"]</label>
             <div class="study-input-row">
                 <input type="number" min="0.5" max="12" step="0.5" @bind="hoursAvailable"/>
-                <button class="button-primary button-accent" @onclick="Calculate">Calculate</button>
+                <button class="button-primary button-accent" @onclick="Calculate">@localizer["Study_Calculate"]</button>
             </div>
         </div>
 
@@ -45,14 +46,14 @@
             {
                 <div class="empty-state" style="margin-top: 2rem">
                     <p class="empty-state-icon">🎉</p>
-                    <p class="empty-state-title">You're all caught up</p>
-                    <p class="empty-state-sub">No upcoming tests — enjoy your free time.</p>
+                    <p class="empty-state-title">@localizer["Study_CaughtUpTitle"]</p>
+                    <p class="empty-state-sub">@localizer["Study_CaughtUpSub"]</p>
                 </div>
             }
             else
             {
                 <div class="study-results">
-                    <p class="study-results-label">Study these today</p>
+                    <p class="study-results-label">@localizer["Study_StudyTheseToday"]</p>
                     @foreach (var test in recommendations)
                     {
                         var score = calculator.CalculateTotalScore(test, allTests);
@@ -62,7 +63,7 @@
                                 <div>
                                     <h3 class="study-card-title">@test.Title</h3>
                                     <p class="study-card-subject">
-                                        @(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? "Unknown") · in @days day@(days == 1 ? "" : "s")
+                                        @(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? localizer["Common_Unknown"].Value) · @(days == 1 ? localizer["Common_InOneDay"] : localizer["Common_InDaysFmt", days])
                                     </p>
                                 </div>
                                 <span class="study-card-score">@score<span class="study-card-score-max">/40</span></span>
@@ -75,16 +76,16 @@
                             @if (studiedTestId == test.Id)
                             {
                                 <div class="studied-prompt">
-                                    <span class="studied-prompt-label">How's your understanding now?</span>
+                                    <span class="studied-prompt-label">@localizer["Study_HowUnderstanding"]</span>
                                     <div class="studied-prompt-row">
                                         <select class="studied-select" @bind="updatedUnderstanding">
                                             @foreach (var u in Enum.GetValues<Test.PersonalUnderstanding>())
                                             {
-                                                <option value="@u">@Test.UnderstandingHelper(u)</option>
+                                                <option value="@u">@localizer[$"Level_{u}"]</option>
                                             }
                                         </select>
-                                        <button class="button-primary button-accent" @onclick="() => SaveStudiedUnderstanding(test)">Save</button>
-                                        <button class="button-primary" @onclick="CancelStudiedPrompt">Cancel</button>
+                                        <button class="button-primary button-accent" @onclick="() => SaveStudiedUnderstanding(test)">@localizer["Common_Save"]</button>
+                                        <button class="button-primary" @onclick="CancelStudiedPrompt">@localizer["Common_Cancel"]</button>
                                     </div>
                                 </div>
                             }
@@ -92,7 +93,7 @@
                             {
                                 <div class="study-card-footer">
                                     <button class="button-primary studied-btn" @onclick="() => OpenStudiedPrompt(test)">
-                                        ✓ Studied it
+                                        ✓ @localizer["Study_StudiedIt"]
                                     </button>
                                 </div>
                             }
@@ -105,7 +106,7 @@
         else
         {
             <div class="study-input-card">
-                <label class="study-input-label">Hours available each day</label>
+                <label class="study-input-label">@localizer["Study_HoursEachDay"]</label>
                 <div class="weekly-hours-grid">
                     @foreach (var day in weeklyHours.Keys)
                     {
@@ -118,7 +119,7 @@
                     }
                 </div>
                 <button class="button-primary button-accent" style="align-self: flex-start; margin-top: 8px;" @onclick="CalculateWeekly">
-                    Plan my week
+                    @localizer["Study_PlanMyWeek"]
                 </button>
             </div>
 
@@ -132,7 +133,7 @@
                                 <span class="weekly-day-name">@DayLabel(date)</span>
                                 @if (!tests.Any())
                                 {
-                                    <span class="weekly-day-off">Day off</span>
+                                    <span class="weekly-day-off">@localizer["Study_DayOff"]</span>
                                 }
                             </div>
                             @if (tests.Any())
@@ -146,8 +147,8 @@
                                             <div class="weekly-test-info">
                                                 <span class="weekly-test-title">@test.Title</span>
                                                 <span class="weekly-test-meta">
-                                                    @(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? "Unknown")
-                                                    · @days day@(days == 1 ? "" : "s") away
+                                                    @(subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? localizer["Common_Unknown"].Value)
+                                                    · @(days == 1 ? localizer["Study_OneDayAway"] : localizer["Study_DaysAwayFmt", days])
                                                 </span>
                                             </div>
                                             <span class="weekly-test-score @GetGradeClass(score / 40.0 * 6)">@score/40</span>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor
@@ -6,10 +6,10 @@
 
 <div class="page">
     <div class="top-row">
-        <div class="title nav-brand">
+        <a href="/" class="title nav-brand" data-enhance-nav="false">
             <img src="/logo.svg" width="26" height="26" alt="WSIST logo"/>
             <span>WSIST</span>
-        </div>
+        </a>
         <LanguageToggle />
         <a href="/" class="button-primary" data-enhance-nav="false">← @localizer["Common_Back"]</a>
         <a href="/logout" class="button-primary button-danger" data-enhance-nav="false">@localizer["Common_Logout"]</a>

--- a/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
+++ b/WSIST/WSIST.Web/Components/Pages/Study.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Localization;
 using WSIST.Engine;
 
 namespace WSIST.Web.Components.Pages;
@@ -9,7 +10,8 @@ public partial class Study(
     TestManagement management,
     AuthenticationStateProvider authStateProvider,
     NavigationManager navigation,
-    PriorityCalculator calculator
+    PriorityCalculator calculator,
+    IStringLocalizer<SharedResource> localizer
 ) : AuthenticatedComponentBase(management, authStateProvider, navigation)
 {
     private List<Test> allTests = [];
@@ -52,10 +54,10 @@ public partial class Study(
         weeklyCalculated = true;
     }
 
-    private static string DayLabel(DateOnly date)
+    private string DayLabel(DateOnly date)
     {
         var today = DateOnly.FromDateTime(DateTime.Today);
-        return date == today ? "Today" : date.ToString("ddd d MMM");
+        return date == today ? localizer["Study_Today"] : date.ToString("ddd d MMM");
     }
 
     private void OpenStudiedPrompt(Test test)
@@ -97,7 +99,7 @@ public partial class Study(
         var understanding = calculator.CalculateUnderstandingScore(test.Understanding);
         var grade = calculator.CalculateGradeScore(test.Subject, allTests);
 
-        return $"Urgency: {urgency}/10 · Volume: {volume}/12 · Understanding: {understanding}/12 · Grade: {grade}/6";
+        return $"{localizer["Score_Urgency"]}: {urgency}/10 · {localizer["Score_Volume"]}: {volume}/12 · {localizer["Score_Understanding"]}: {understanding}/12 · {localizer["Score_Grade"]}: {grade}/6";
     }
 
     private string GetBecauseText(Test test)
@@ -112,15 +114,18 @@ public partial class Study(
         var subjectName =
             subjects.FirstOrDefault(s => s.Id == test.Subject)?.Name ?? test.Subject.ToString();
 
+        var understandingWord = localizer[$"Level_{test.Understanding}"].Value.ToLowerInvariant();
+        var volumeWord = localizer[$"Level_{test.Volume}"].Value.ToLowerInvariant();
+
         var parts = new List<string>
         {
-            $"you have {Test.UnderstandingHelper(test.Understanding).ToLower()} understanding",
-            $"the test has {Test.VolumeHelper(test.Volume).ToLower()} volume",
-            $"it's in {days} day{(days == 1 ? "" : "s")}",
+            localizer["Because_Understanding", understandingWord],
+            localizer["Because_Volume", volumeWord],
+            days == 1 ? localizer["Because_InOneDay"] : localizer["Because_InDaysFmt", days],
         };
 
         if (avgGrade > 0)
-            parts.Add($"your average grade in {subjectName} is {avgGrade:F1}");
+            parts.Add(localizer["Because_AvgGradeFmt", subjectName, avgGrade.ToString("F1")]);
 
         return string.Join(", ", parts);
     }

--- a/WSIST/WSIST.Web/Components/Pages/Terms.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Terms.razor
@@ -1,7 +1,8 @@
 @page "/terms"
 @layout EmptyLayout
 @using WSIST.Web.Components.Layout
-<PageTitle>Terms of Use – WSIST</PageTitle>
+@inject IStringLocalizer<SharedResource> Localizer
+<PageTitle>@Localizer["Terms_Title"] – WSIST</PageTitle>
 
 <div class="legal-page">
     <nav class="landing-nav">
@@ -9,51 +10,29 @@
             <img src="/logo.svg" width="32" height="32" alt="WSIST" />
             <span>WSIST</span>
         </div>
-        <a href="/login-page" class="landing-cta-sm" style="color: var(--text-secondary); text-decoration: none;">← Back</a>
+        <div class="landing-nav-actions">
+            <LanguageToggle />
+            <a href="/login-page" class="landing-cta-sm" style="color: var(--text-secondary); text-decoration: none;">← @Localizer["Common_Back"]</a>
+        </div>
     </nav>
 
     <div class="legal-content">
-        <h1>Terms of Use</h1>
-        <p class="legal-meta">Last updated: @(new DateTime(2026, 6, 1).ToString("MMMM d, yyyy"))</p>
+        <h1>@Localizer["Terms_Title"]</h1>
+        <p class="legal-meta">@Localizer["Legal_LastUpdated"] @(new DateTime(2026, 6, 1).ToString("MMMM d, yyyy"))</p>
 
-        <h2>1. Acceptance of terms</h2>
-        <p>By accessing or using WSIST ("What Should I Study Today") at wsist.forch.me, you agree to be bound by these Terms of Use. If you do not agree, do not use the service.</p>
-
-        <h2>2. Description of service</h2>
-        <p>WSIST is a personal study planning tool that helps students track upcoming tests, estimate their preparedness, and determine what to study on a given day. The service is provided free of charge for personal, non-commercial use.</p>
-
-        <h2>3. Account and access</h2>
-        <p>Access to WSIST requires a Google account. By signing in, you authorise WSIST to receive your name and email address from Google as described in our <a href="/privacy">Privacy Policy</a>. You are responsible for keeping your Google account secure.</p>
-        <p>One account per person. You may not share your account with others or create accounts on behalf of third parties.</p>
-
-        <h2>4. Acceptable use</h2>
-        <p>You agree not to:</p>
-        <ul>
-            <li>Use WSIST for any unlawful purpose</li>
-            <li>Attempt to access other users' data</li>
-            <li>Attempt to reverse-engineer, disrupt, or overload the service</li>
-            <li>Use automated tools to scrape or extract data from the service</li>
-        </ul>
-
-        <h2>5. Your content</h2>
-        <p>You own the data you enter into WSIST (test entries, subjects, grades). We do not claim any ownership over it. You grant us a limited licence to store and process it solely for the purpose of providing the service to you.</p>
-
-        <h2>6. Service availability</h2>
-        <p>WSIST is a personal project and is provided on an "as is" and "as available" basis. We make no guarantees about uptime, data preservation, or continued availability. We may modify or discontinue the service at any time without notice.</p>
-
-        <h2>7. Disclaimer of warranties</h2>
-        <p>To the fullest extent permitted by law, WSIST is provided without warranties of any kind, express or implied. We do not warrant that the service will be error-free, uninterrupted, or that the study recommendations it produces will lead to any particular academic outcome.</p>
-
-        <h2>8. Limitation of liability</h2>
-        <p>To the fullest extent permitted by applicable law, Tim Hug and the WSIST project shall not be liable for any indirect, incidental, or consequential damages arising from your use of or inability to use the service.</p>
-
-        <h2>9. Changes to terms</h2>
-        <p>We may update these terms at any time. The "last updated" date at the top of this page will reflect any changes. Continued use of WSIST after changes are posted constitutes acceptance of the updated terms.</p>
-
-        <h2>10. Governing law</h2>
-        <p>These terms are governed by the laws of Switzerland, without regard to conflict of law principles. Any disputes arising from these terms shall be subject to the exclusive jurisdiction of the courts of the Canton of Zurich, Switzerland.</p>
-
-        <h2>11. Contact</h2>
-        <p>Questions about these terms? Contact us at <a href="mailto:privacy@wsist.forch.me">privacy@wsist.forch.me</a>.</p>
+        @* Section bodies are static, developer-authored HTML stored in the
+           resource files; rendered as markup so inline emphasis and links
+           survive translation. No user input is involved. *@
+        @((MarkupString)Localizer["Terms_Sec1"].Value)
+        @((MarkupString)Localizer["Terms_Sec2"].Value)
+        @((MarkupString)Localizer["Terms_Sec3"].Value)
+        @((MarkupString)Localizer["Terms_Sec4"].Value)
+        @((MarkupString)Localizer["Terms_Sec5"].Value)
+        @((MarkupString)Localizer["Terms_Sec6"].Value)
+        @((MarkupString)Localizer["Terms_Sec7"].Value)
+        @((MarkupString)Localizer["Terms_Sec8"].Value)
+        @((MarkupString)Localizer["Terms_Sec9"].Value)
+        @((MarkupString)Localizer["Terms_Sec10"].Value)
+        @((MarkupString)Localizer["Terms_Sec11"].Value)
     </div>
 </div>

--- a/WSIST/WSIST.Web/Components/_Imports.razor
+++ b/WSIST/WSIST.Web/Components/_Imports.razor
@@ -10,3 +10,4 @@
 @using WSIST.Web.Components
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.Extensions.Localization

--- a/WSIST/WSIST.Web/DbRequestCultureProvider.cs
+++ b/WSIST/WSIST.Web/DbRequestCultureProvider.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Localization;
+using WSIST.Engine;
+
+namespace WSIST.Web;
+
+// Resolves the UI language for a signed-in user from their stored
+// PreferredLanguage. Runs ahead of the cookie and Accept-Language providers, so
+// a saved preference wins and persists across logout/login (and across devices).
+// While PreferredLanguage is null this returns null and the next provider
+// (cookie, then Accept-Language) decides — that's how a first-time user defaults
+// to their browser language.
+public sealed class DbRequestCultureProvider : RequestCultureProvider
+{
+    public override Task<ProviderCultureResult?> DetermineProviderCultureResult(
+        HttpContext httpContext
+    )
+    {
+        if (httpContext.User?.Identity?.IsAuthenticated != true)
+            return Task.FromResult<ProviderCultureResult?>(null);
+
+        var email = httpContext.User.FindFirst(ClaimTypes.Email)?.Value;
+        if (string.IsNullOrEmpty(email))
+            return Task.FromResult<ProviderCultureResult?>(null);
+
+        var management = httpContext.RequestServices.GetService<TestManagement>();
+        var lang = management?.GetPreferredLanguageByEmail(email);
+        if (string.IsNullOrEmpty(lang))
+            return Task.FromResult<ProviderCultureResult?>(null);
+
+        return Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(lang));
+    }
+}

--- a/WSIST/WSIST.Web/DbRequestCultureProvider.cs
+++ b/WSIST/WSIST.Web/DbRequestCultureProvider.cs
@@ -12,22 +12,28 @@ namespace WSIST.Web;
 // to their browser language.
 public sealed class DbRequestCultureProvider : RequestCultureProvider
 {
-    public override Task<ProviderCultureResult?> DetermineProviderCultureResult(
+    public override async Task<ProviderCultureResult?> DetermineProviderCultureResult(
         HttpContext httpContext
     )
     {
         if (httpContext.User?.Identity?.IsAuthenticated != true)
-            return Task.FromResult<ProviderCultureResult?>(null);
+            return null;
 
         var email = httpContext.User.FindFirst(ClaimTypes.Email)?.Value;
         if (string.IsNullOrEmpty(email))
-            return Task.FromResult<ProviderCultureResult?>(null);
+            return null;
 
         var management = httpContext.RequestServices.GetService<TestManagement>();
-        var lang = management?.GetPreferredLanguageByEmail(email);
-        if (string.IsNullOrEmpty(lang))
-            return Task.FromResult<ProviderCultureResult?>(null);
+        if (management is null)
+            return null;
 
-        return Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(lang));
+        var lang = await management.GetPreferredLanguageByEmailAsync(
+            email,
+            httpContext.RequestAborted
+        );
+        if (string.IsNullOrEmpty(lang))
+            return null;
+
+        return new ProviderCultureResult(lang);
     }
 }

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
@@ -125,6 +127,54 @@ app.MapGet(
             var averages = management.GetGradeAverages(user.Id);
 
             return Results.Ok(new { userId = user.Id, subjects = averages });
+        }
+    )
+    .RequireAuthorization();
+
+app.MapGet(
+        "/api/export",
+        (HttpContext ctx, TestManagement management, string? format) =>
+        {
+            if (!ctx.User.Identity?.IsAuthenticated ?? true)
+                return Results.Unauthorized();
+
+            var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
+            if (email is null)
+                return Results.Unauthorized();
+
+            // Resolve the user from their own authenticated claims and scope the
+            // export strictly to that id. The caller cannot supply a user id, so
+            // one user's export can never contain another user's rows. This
+            // endpoint exists for nDSG / GDPR data portability.
+            var user = management.GetOrCreateUser(
+                email,
+                ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",
+                ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ""
+            );
+
+            var rows = management.GetTestExport(user.Id);
+
+            if (string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+            {
+                var json = JsonSerializer.Serialize(
+                    rows,
+                    new JsonSerializerOptions { WriteIndented = true }
+                );
+                return Results.File(
+                    Encoding.UTF8.GetBytes(json),
+                    "application/json",
+                    "wsist-tests.json"
+                );
+            }
+
+            // Default to CSV. Prepend a UTF-8 BOM so spreadsheet apps (Excel)
+            // render accented characters — relevant for German subject names.
+            var csv = TestExporter.ToCsv(rows);
+            var csvBytes = Encoding
+                .UTF8.GetPreamble()
+                .Concat(Encoding.UTF8.GetBytes(csv))
+                .ToArray();
+            return Results.File(csvBytes, "text/csv", "wsist-tests.csv");
         }
     )
     .RequireAuthorization();

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -5,13 +6,31 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.EntityFrameworkCore;
 using WSIST.Engine;
+using WSIST.Web;
 using WSIST.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+// UI text can be English or German; data formatting (dates, grade decimals) is
+// pinned to English so switching language never changes how a "5.5" grade is
+// parsed or shown. Hence one supported *culture* (en) but two supported *UI
+// cultures* (en, de) — only the UI culture, which IStringLocalizer reads, flips.
+var supportedUICultures = new[] { new CultureInfo("en"), new CultureInfo("de") };
+builder.Services.Configure<RequestLocalizationOptions>(options =>
+{
+    options.DefaultRequestCulture = new RequestCulture("en");
+    options.SupportedCultures = new[] { new CultureInfo("en") };
+    options.SupportedUICultures = supportedUICultures;
+    // A signed-in user's saved preference wins; otherwise the cookie (set by the
+    // toggle), then the browser's Accept-Language header, then English.
+    options.RequestCultureProviders.Insert(0, new DbRequestCultureProvider());
+});
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
@@ -65,6 +84,9 @@ if (!app.Environment.IsDevelopment())
 app.UseForwardedHeaders();
 app.UseAuthentication();
 app.UseAuthorization();
+
+// After authentication so the DB culture provider can read the signed-in user.
+app.UseRequestLocalization();
 app.UseAntiforgery();
 
 app.Use(
@@ -179,6 +201,57 @@ app.MapGet(
         }
     )
     .RequireAuthorization();
+
+app.MapGet(
+        "/set-language/{culture}",
+        (string culture, string? redirectUri, HttpContext ctx, TestManagement management) =>
+        {
+            // Only ever honour the two languages we ship; anything else is English.
+            var lang = culture == "de" ? "de" : "en";
+
+            // Persist the choice: a cookie (covers anonymous visitors and the
+            // immediate post-redirect render) and, for signed-in users, the
+            // durable DB preference that survives logout/login.
+            ctx.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(lang)),
+                new CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
+                    IsEssential = true,
+                    Path = "/",
+                    SameSite = SameSiteMode.Lax,
+                    Secure = true,
+                }
+            );
+
+            if (ctx.User.Identity?.IsAuthenticated == true)
+            {
+                var email = ctx.User.FindFirst(ClaimTypes.Email)?.Value;
+                if (email is not null)
+                {
+                    var user = management.GetOrCreateUser(
+                        email,
+                        ctx.User.FindFirst(ClaimTypes.Name)?.Value ?? "Unknown",
+                        ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ""
+                    );
+                    management.UpdatePreferredLanguage(user.Id, lang);
+                }
+            }
+
+            // Only redirect to a local relative path — never an absolute or
+            // protocol-relative URL — so this can't be used as an open redirect.
+            var target =
+                !string.IsNullOrEmpty(redirectUri)
+                && Uri.IsWellFormedUriString(redirectUri, UriKind.Relative)
+                && redirectUri.StartsWith('/')
+                && !redirectUri.StartsWith("//")
+                    ? redirectUri
+                    : "/";
+            return Results.LocalRedirect(target);
+        }
+    )
+    .AllowAnonymous();
 
 using (var scope = app.Services.CreateScope())
 {

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -50,6 +50,7 @@ builder
     });
 
 builder.Services.AddScoped<TestManagement>();
+builder.Services.AddScoped<FeedbackManagement>();
 builder.Services.AddScoped<PriorityCalculator>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddCascadingAuthenticationState();
@@ -70,7 +71,7 @@ app.Use(
     async (context, next) =>
     {
         var isAuthenticated = context.User?.Identity?.IsAuthenticated ?? false;
-        var protectedPaths = new[] { "/", "/study", "/settings" };
+        var protectedPaths = new[] { "/", "/study", "/settings", "/feedback" };
         if (
             protectedPaths.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase)
             && !isAuthenticated

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -167,7 +167,7 @@
   <data name="Settings_SubjectInUseError" xml:space="preserve"><value>Ein Fach mit zugeordneten Prüfungen kann nicht gelöscht werden. Lösche oder verschiebe diese Prüfungen zuerst.</value></data>
   <data name="Settings_Data" xml:space="preserve"><value>Daten</value></data>
   <data name="Settings_ExportTitle" xml:space="preserve"><value>Meine Daten exportieren</value></data>
-  <data name="Settings_ExportSub" xml:space="preserve"><value>Lade alle deine Prüfungen und Noten herunter, einschließlich vergangener benoteter.</value></data>
+  <data name="Settings_ExportSub" xml:space="preserve"><value>Lade alle deine Prüfungen und Noten herunter, einschließlich vergangener benoteter Prüfungen.</value></data>
   <data name="Settings_Feedback" xml:space="preserve"><value>Feedback</value></data>
   <data name="Settings_FeedbackTitle" xml:space="preserve"><value>Feedback &amp; Funktionswünsche</value></data>
   <data name="Settings_FeedbackSub" xml:space="preserve"><value>Melde einen Fehler oder schlage eine Verbesserung vor.</value></data>
@@ -197,6 +197,7 @@
   <data name="Feedback_AdminTitle" xml:space="preserve"><value>Alle Einsendungen (Admin)</value></data>
   <data name="Feedback_Empty" xml:space="preserve"><value>Noch kein Feedback eingegangen.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Die Feedback-Nachricht darf nicht leer sein.</value></data>
+  <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Dein Feedback konnte nicht übermittelt werden. Bitte überprüfe deine Nachricht und versuche es erneut.</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Offen</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Geprüft</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Geschlossen</value></data>
@@ -291,7 +292,9 @@
   <data name="Landing_Feat4Desc" xml:space="preserve"><value>Nichts Neues zu merken. Dein Schulkonto funktioniert problemlos.</value></data>
   <data name="Landing_Feat5Title" xml:space="preserve"><value>Privat von Haus aus</value></data>
   <data name="Landing_Feat5Desc" xml:space="preserve"><value>Deine Prüfungen und Noten sind nur für dich sichtbar, und du kannst sie jederzeit löschen. Keine Werbung, niemals.</value></data>
+  <data name="Landing_WsistSays" xml:space="preserve"><value>„WSIST sagt“</value></data>
   <data name="Landing_Soon" xml:space="preserve"><value>Bald</value></data>
+  <data name="Landing_ManifestoAttribution" xml:space="preserve"><value>Tim · Informatik-Lehrling · Zürich</value></data>
   <data name="Landing_Feat6Desc" xml:space="preserve"><value>Ein tägliches Lern-Briefing auf Schweizerdeutsch, dazu eine Android-App. Entsteht zwischen den Prüfungswochen.</value></data>
   <data name="Landing_ManifestoPre" xml:space="preserve"><value>Entstanden zwischen Lehrlingsschichten und Prüfungswochen — von einem Schüler, der </value></data>
   <data name="Landing_ManifestoBold" xml:space="preserve"><value>wollte, dass es existiert.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -300,6 +300,97 @@
   <data name="Landing_CtaSmall" xml:space="preserve"><value>Kostenlos · läuft in jedem Browser</value></data>
   <data name="Landing_FooterMade" xml:space="preserve"><value>Erstellt in Zürich · © 2026 Tim Hug</value></data>
 
+  <!-- ===== Legal: shared ===== -->
+  <data name="Legal_LastUpdated" xml:space="preserve"><value>Zuletzt aktualisiert:</value></data>
+
+  <!-- ===== Privacy policy (section bodies rendered as MarkupString) ===== -->
+  <data name="Privacy_Title" xml:space="preserve"><value>Datenschutzerklärung</value></data>
+  <data name="Privacy_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Wer wir sind&lt;/h2&gt;
+&lt;p&gt;WSIST („What Should I Study Today“) ist eine persönliche Lernplanungs-Anwendung, entwickelt und betrieben von Tim Hug mit Sitz in der Schweiz. Diese Datenschutzerklärung erläutert, welche personenbezogenen Daten wir erheben, wie wir sie verwenden und welche Rechte du hast.&lt;/p&gt;
+&lt;p&gt;Kontakt: &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Daten, die wir erheben&lt;/h2&gt;
+&lt;p&gt;Wenn du dich mit Google anmeldest, erhalten und speichern wir die folgenden Daten aus Googles OAuth-Dienst:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;strong&gt;E-Mail-Adresse&lt;/strong&gt; — zur Identifikation deines Kontos&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Anzeigename&lt;/strong&gt; — in der Anwendung angezeigt&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Google-Benutzer-ID&lt;/strong&gt; — zur Verknüpfung deines Google-Kontos mit deinem WSIST-Konto&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Wir speichern außerdem Daten, die du bei der Nutzung der Anwendung erstellst:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Prüfungseinträge (Titel, Fach, Fälligkeitsdatum, Umfang, Verständnisgrad, Note)&lt;/li&gt;
+&lt;li&gt;Von dir erstellte eigene Fächer&lt;/li&gt;
+&lt;li&gt;Deinen Anzeigenamen, falls du ihn in den Einstellungen änderst&lt;/li&gt;
+&lt;li&gt;Den Zeitstempel der Kontoerstellung&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Wir erheben keine Standortdaten, Gerätekennungen oder Daten, die über das oben Genannte hinausgehen.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. Wie wir deine Daten verwenden&lt;/h2&gt;
+&lt;p&gt;Deine Daten werden ausschließlich zur Bereitstellung des WSIST-Dienstes verwendet:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Deine Authentifizierung beim Anmelden&lt;/li&gt;
+&lt;li&gt;Speicherung und Anzeige deiner Prüfungseinträge&lt;/li&gt;
+&lt;li&gt;Berechnung von Lernempfehlungen und Prioritätspunktzahlen&lt;/li&gt;
+&lt;li&gt;Anzeige deiner Notenübersicht&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Wir verkaufen deine Daten nicht, geben sie nicht an Werbetreibende weiter und verwenden sie für keinen anderen Zweck als die Bereitstellung des Dienstes.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec4" xml:space="preserve"><value>&lt;h2&gt;4. Rechtsgrundlage der Verarbeitung (DSGVO / Schweizer nDSG)&lt;/h2&gt;
+&lt;p&gt;Wir verarbeiten deine personenbezogenen Daten auf Grundlage der &lt;strong&gt;Vertragserfüllung&lt;/strong&gt; (Art. 6 Abs. 1 lit. b DSGVO) — die Verarbeitung ist erforderlich, um den von dir angeforderten Dienst bereitzustellen. Mit der Erstellung eines Kontos und der Nutzung von WSIST schließt du mit uns einen Vertrag über die Bereitstellung der Anwendung.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Dienste von Drittanbietern&lt;/h2&gt;
+&lt;p&gt;&lt;strong&gt;Google OAuth:&lt;/strong&gt; Die Anmeldung erfolgt über Googles OAuth-2.0-Dienst. Bei der Authentifizierung teilt Google deine Profildaten mit uns, wie in Abschnitt 2 beschrieben. Für den Authentifizierungsvorgang gilt Googles eigene Datenschutzerklärung: &lt;a href="https://policies.google.com/privacy" target="_blank" rel="noopener"&gt;policies.google.com/privacy&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Railway:&lt;/strong&gt; Die Anwendung wird bei Railway (railway.app) gehostet. Deine Daten werden in einer MySQL-Datenbank auf deren Infrastruktur gespeichert. Für das Hosting gilt die Datenschutzerklärung von Railway: &lt;a href="https://railway.app/legal/privacy" target="_blank" rel="noopener"&gt;railway.app/legal/privacy&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; Die Anwendung wird über das CDN von Cloudflare ausgeliefert. Cloudflare verarbeitet im Rahmen seines Dienstes möglicherweise Verbindungsmetadaten (IP-Adresse, Anfrage-Header). Datenschutzerklärung von Cloudflare: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Speicherdauer&lt;/h2&gt;
+&lt;p&gt;Deine Daten werden so lange gespeichert, wie du ein aktives Konto hast. Wenn du dein Konto und alle zugehörigen Daten löschen möchtest, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;, und wir löschen sie innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Deine Rechte&lt;/h2&gt;
+&lt;p&gt;Nach DSGVO und Schweizer nDSG hast du die folgenden Rechte:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;strong&gt;Auskunft:&lt;/strong&gt; Du kannst eine Kopie aller personenbezogenen Daten anfordern, die wir über dich gespeichert haben.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Berichtigung:&lt;/strong&gt; Du kannst unrichtige Daten über die Einstellungsseite oder durch Kontaktaufnahme mit uns korrigieren.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Löschung:&lt;/strong&gt; Du kannst die Löschung deines Kontos und aller zugehörigen Daten verlangen.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Datenübertragbarkeit:&lt;/strong&gt; Du kannst deine Daten in einem maschinenlesbaren Format anfordern.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Widerspruch:&lt;/strong&gt; Du kannst der Verarbeitung unter bestimmten Umständen widersprechen.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Um eines dieser Rechte auszuüben, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;. Wir antworten innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Cookies und Sitzungen&lt;/h2&gt;
+&lt;p&gt;WSIST verwendet ein einziges Authentifizierungs-Cookie (.AspNetCore.Cookies), um deine Anmeldesitzung aufrechtzuerhalten. Dieses Cookie ist für die Funktion der Anwendung zwingend erforderlich und verfolgt dich nicht über andere Websites hinweg. Es werden keine Analyse-, Werbe- oder Tracking-Cookies von Dritten verwendet.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Sicherheit&lt;/h2&gt;
+&lt;p&gt;Deine Daten werden über HTTPS übertragen. Passwörter werden niemals gespeichert — die Authentifizierung erfolgt vollständig über Google. Der Datenbankzugriff ist ausschließlich der Anwendung vorbehalten.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Änderungen dieser Erklärung&lt;/h2&gt;
+&lt;p&gt;Wenn wir wesentliche Änderungen an dieser Erklärung vornehmen, aktualisieren wir das Datum „Zuletzt aktualisiert“ oben auf dieser Seite. Die fortgesetzte Nutzung von WSIST nach Änderungen gilt als Annahme der aktualisierten Erklärung.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Kontakt&lt;/h2&gt;
+&lt;p&gt;Fragen zu dieser Datenschutzerklärung? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+
+  <!-- ===== Terms of use (section bodies rendered as MarkupString) ===== -->
+  <data name="Terms_Title" xml:space="preserve"><value>Nutzungsbedingungen</value></data>
+  <data name="Terms_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Annahme der Bedingungen&lt;/h2&gt;
+&lt;p&gt;Durch den Zugriff auf oder die Nutzung von WSIST („What Should I Study Today“) unter wsist.forch.me erklärst du dich mit diesen Nutzungsbedingungen einverstanden. Wenn du nicht einverstanden bist, nutze den Dienst nicht.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Beschreibung des Dienstes&lt;/h2&gt;
+&lt;p&gt;WSIST ist ein persönliches Lernplanungs-Werkzeug, das Schülern hilft, anstehende Prüfungen zu verfolgen, ihren Vorbereitungsstand einzuschätzen und zu bestimmen, was an einem bestimmten Tag zu lernen ist. Der Dienst wird kostenlos für den persönlichen, nicht-kommerziellen Gebrauch bereitgestellt.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. Konto und Zugang&lt;/h2&gt;
+&lt;p&gt;Der Zugang zu WSIST erfordert ein Google-Konto. Mit der Anmeldung autorisierst du WSIST, deinen Namen und deine E-Mail-Adresse von Google zu erhalten, wie in unserer &lt;a href="/privacy"&gt;Datenschutzerklärung&lt;/a&gt; beschrieben. Du bist dafür verantwortlich, dein Google-Konto sicher zu halten.&lt;/p&gt;
+&lt;p&gt;Ein Konto pro Person. Du darfst dein Konto nicht mit anderen teilen oder Konten im Namen Dritter erstellen.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec4" xml:space="preserve"><value>&lt;h2&gt;4. Zulässige Nutzung&lt;/h2&gt;
+&lt;p&gt;Du verpflichtest dich, Folgendes zu unterlassen:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;WSIST für rechtswidrige Zwecke zu nutzen&lt;/li&gt;
+&lt;li&gt;Zu versuchen, auf Daten anderer Nutzer zuzugreifen&lt;/li&gt;
+&lt;li&gt;Zu versuchen, den Dienst zurückzuentwickeln, zu stören oder zu überlasten&lt;/li&gt;
+&lt;li&gt;Automatisierte Werkzeuge zu verwenden, um Daten aus dem Dienst auszulesen oder zu extrahieren&lt;/li&gt;
+&lt;/ul&gt;</value></data>
+  <data name="Terms_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Deine Inhalte&lt;/h2&gt;
+&lt;p&gt;Die Daten, die du in WSIST eingibst (Prüfungseinträge, Fächer, Noten), gehören dir. Wir erheben keinen Anspruch auf Eigentum daran. Du gewährst uns eine eingeschränkte Lizenz, sie ausschließlich zum Zweck der Bereitstellung des Dienstes für dich zu speichern und zu verarbeiten.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Verfügbarkeit des Dienstes&lt;/h2&gt;
+&lt;p&gt;WSIST ist ein persönliches Projekt und wird „wie besehen“ und „nach Verfügbarkeit“ bereitgestellt. Wir geben keine Garantien für Verfügbarkeit, Datenerhalt oder fortlaufenden Betrieb. Wir können den Dienst jederzeit ohne Vorankündigung ändern oder einstellen.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Gewährleistungsausschluss&lt;/h2&gt;
+&lt;p&gt;Soweit gesetzlich zulässig, wird WSIST ohne jegliche ausdrückliche oder stillschweigende Gewährleistung bereitgestellt. Wir gewährleisten nicht, dass der Dienst fehlerfrei oder ununterbrochen ist oder dass die von ihm erstellten Lernempfehlungen zu einem bestimmten schulischen Ergebnis führen.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Haftungsbeschränkung&lt;/h2&gt;
+&lt;p&gt;Soweit nach geltendem Recht zulässig, haften Tim Hug und das WSIST-Projekt nicht für indirekte, beiläufig entstandene oder Folgeschäden, die sich aus deiner Nutzung oder Nichtnutzung des Dienstes ergeben.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Änderungen der Bedingungen&lt;/h2&gt;
+&lt;p&gt;Wir können diese Bedingungen jederzeit aktualisieren. Das Datum „Zuletzt aktualisiert“ oben auf dieser Seite spiegelt etwaige Änderungen wider. Die fortgesetzte Nutzung von WSIST nach Veröffentlichung von Änderungen gilt als Annahme der aktualisierten Bedingungen.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Anwendbares Recht&lt;/h2&gt;
+&lt;p&gt;Diese Bedingungen unterliegen dem Recht der Schweiz, unter Ausschluss der Kollisionsnormen. Für alle Streitigkeiten aus diesen Bedingungen sind ausschließlich die Gerichte des Kantons Zürich, Schweiz, zuständig.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Kontakt&lt;/h2&gt;
+&lt;p&gt;Fragen zu diesen Bedingungen? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Seite nicht gefunden</value></data>
   <data name="NotFound_Sub" xml:space="preserve"><value>Die gesuchte Seite existiert nicht oder wurde verschoben.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <!-- ===== Common / shared ===== -->
+  <data name="Common_Back" xml:space="preserve"><value>Zurück</value></data>
+  <data name="Common_Logout" xml:space="preserve"><value>Abmelden</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="Common_Save" xml:space="preserve"><value>Speichern</value></data>
+  <data name="Common_Add" xml:space="preserve"><value>Hinzufügen</value></data>
+  <data name="Common_Delete" xml:space="preserve"><value>Löschen</value></data>
+  <data name="Common_Edit" xml:space="preserve"><value>Bearbeiten</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>Öffnen</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Unbekannt</value></data>
+  <data name="Common_Settings" xml:space="preserve"><value>Einstellungen</value></data>
+  <data name="Common_Study" xml:space="preserve"><value>Lernen</value></data>
+  <data name="Common_BackToHome" xml:space="preserve"><value>Zur Startseite</value></data>
+  <data name="Common_ContinueWithGoogle" xml:space="preserve"><value>Mit Google anmelden</value></data>
+  <data name="Common_Points" xml:space="preserve"><value>Pkt.</value></data>
+  <data name="Common_InOneDay" xml:space="preserve"><value>in 1 Tag</value></data>
+  <data name="Common_InDaysFmt" xml:space="preserve"><value>in {0} Tagen</value></data>
+
+  <!-- ===== Volume / understanding levels ===== -->
+  <data name="Level_VeryLow" xml:space="preserve"><value>Sehr niedrig</value></data>
+  <data name="Level_Low" xml:space="preserve"><value>Niedrig</value></data>
+  <data name="Level_Medium" xml:space="preserve"><value>Mittel</value></data>
+  <data name="Level_Average" xml:space="preserve"><value>Durchschnittlich</value></data>
+  <data name="Level_High" xml:space="preserve"><value>Hoch</value></data>
+  <data name="Level_VeryHigh" xml:space="preserve"><value>Sehr hoch</value></data>
+
+  <!-- ===== Subject validation (shared by Home modal + Settings) ===== -->
+  <data name="Subject_EmptyError" xml:space="preserve"><value>Der Fachname darf nicht leer sein.</value></data>
+  <data name="Subject_DuplicateError" xml:space="preserve"><value>Ein Fach mit diesem Namen existiert bereits.</value></data>
+
+  <!-- ===== Home ===== -->
+  <data name="Home_Title" xml:space="preserve"><value>Deine Prüfungen</value></data>
+  <data name="Home_Subtitle" xml:space="preserve"><value>Anstehende Prüfungen und Tests.</value></data>
+  <data name="Home_ShowPast" xml:space="preserve"><value>Vergangene anzeigen</value></data>
+  <data name="Home_HidePast" xml:space="preserve"><value>Vergangene ausblenden</value></data>
+  <data name="Home_AddTest" xml:space="preserve"><value>Prüfung hinzufügen</value></data>
+  <data name="Home_EnterMissingGrades" xml:space="preserve"><value>Fehlende Noten eintragen</value></data>
+  <data name="Home_StudyToday" xml:space="preserve"><value>Heute lernen</value></data>
+  <data name="Home_FullPlan" xml:space="preserve"><value>Ganzer Plan</value></data>
+  <data name="Home_NoUpcomingTitle" xml:space="preserve"><value>Keine anstehenden Prüfungen</value></data>
+  <data name="Home_NoUpcomingSub" xml:space="preserve"><value>Füge deine erste Prüfung hinzu, um loszulegen.</value></data>
+  <data name="Home_ColTitle" xml:space="preserve"><value>Titel</value></data>
+  <data name="Home_ColSubject" xml:space="preserve"><value>Fach</value></data>
+  <data name="Home_ColDate" xml:space="preserve"><value>Datum</value></data>
+  <data name="Home_ColVolume" xml:space="preserve"><value>Umfang</value></data>
+  <data name="Home_ColUnderstanding" xml:space="preserve"><value>Verständnis</value></data>
+  <data name="Home_Grades" xml:space="preserve"><value>Noten</value></data>
+  <data name="Home_GradeTrends" xml:space="preserve"><value>Notenverlauf</value></data>
+  <data name="Home_TestCountOne" xml:space="preserve"><value>1 Prüfung</value></data>
+  <data name="Home_TestCountFmt" xml:space="preserve"><value>{0} Prüfungen</value></data>
+
+  <!-- ===== Test modal ===== -->
+  <data name="Modal_AddTest" xml:space="preserve"><value>Prüfung hinzufügen</value></data>
+  <data name="Modal_EditTest" xml:space="preserve"><value>Prüfung bearbeiten</value></data>
+  <data name="Modal_Title" xml:space="preserve"><value>Titel</value></data>
+  <data name="Modal_TitlePlaceholder" xml:space="preserve"><value>z. B. Mathe-Prüfung</value></data>
+  <data name="Modal_Subject" xml:space="preserve"><value>Fach</value></data>
+  <data name="Modal_AddNewSubject" xml:space="preserve"><value>+ Neues Fach hinzufügen</value></data>
+  <data name="Modal_NewSubjectPlaceholder" xml:space="preserve"><value>Name des neuen Fachs</value></data>
+  <data name="Modal_DueDate" xml:space="preserve"><value>Fälligkeitsdatum</value></data>
+  <data name="Modal_Volume" xml:space="preserve"><value>Umfang</value></data>
+  <data name="Modal_Understanding" xml:space="preserve"><value>Verständnis</value></data>
+  <data name="Modal_Grade" xml:space="preserve"><value>Note</value></data>
+  <data name="Modal_GradeAfterDate" xml:space="preserve"><value>(verfügbar nach dem Prüfungsdatum)</value></data>
+  <data name="Modal_SaveChanges" xml:space="preserve"><value>Änderungen speichern</value></data>
+
+  <!-- ===== Study ===== -->
+  <data name="Study_Title" xml:space="preserve"><value>Was soll ich lernen?</value></data>
+  <data name="Study_Subtitle" xml:space="preserve"><value>Sag uns, wie viel Zeit du hast — den Rest übernehmen wir.</value></data>
+  <data name="Study_Today" xml:space="preserve"><value>Heute</value></data>
+  <data name="Study_ThisWeek" xml:space="preserve"><value>Diese Woche</value></data>
+  <data name="Study_HoursToday" xml:space="preserve"><value>Heute verfügbare Stunden</value></data>
+  <data name="Study_Calculate" xml:space="preserve"><value>Berechnen</value></data>
+  <data name="Study_CaughtUpTitle" xml:space="preserve"><value>Alles erledigt</value></data>
+  <data name="Study_CaughtUpSub" xml:space="preserve"><value>Keine anstehenden Prüfungen — genieße deine freie Zeit.</value></data>
+  <data name="Study_StudyTheseToday" xml:space="preserve"><value>Lerne diese heute</value></data>
+  <data name="Study_HowUnderstanding" xml:space="preserve"><value>Wie ist dein Verständnis jetzt?</value></data>
+  <data name="Study_StudiedIt" xml:space="preserve"><value>Gelernt</value></data>
+  <data name="Study_HoursEachDay" xml:space="preserve"><value>Pro Tag verfügbare Stunden</value></data>
+  <data name="Study_PlanMyWeek" xml:space="preserve"><value>Meine Woche planen</value></data>
+  <data name="Study_DayOff" xml:space="preserve"><value>Freier Tag</value></data>
+  <data name="Study_OneDayAway" xml:space="preserve"><value>noch 1 Tag</value></data>
+  <data name="Study_DaysAwayFmt" xml:space="preserve"><value>noch {0} Tage</value></data>
+  <data name="Score_Urgency" xml:space="preserve"><value>Dringlichkeit</value></data>
+  <data name="Score_Volume" xml:space="preserve"><value>Umfang</value></data>
+  <data name="Score_Understanding" xml:space="preserve"><value>Verständnis</value></data>
+  <data name="Score_Grade" xml:space="preserve"><value>Note</value></data>
+  <data name="Because_Understanding" xml:space="preserve"><value>dein Verständnis ist {0}</value></data>
+  <data name="Because_Volume" xml:space="preserve"><value>der Umfang ist {0}</value></data>
+  <data name="Because_InOneDay" xml:space="preserve"><value>sie ist in 1 Tag</value></data>
+  <data name="Because_InDaysFmt" xml:space="preserve"><value>sie ist in {0} Tagen</value></data>
+  <data name="Because_AvgGradeFmt" xml:space="preserve"><value>dein Notendurchschnitt in {0} ist {1}</value></data>
+
+  <!-- ===== Settings ===== -->
+  <data name="Settings_Title" xml:space="preserve"><value>Einstellungen</value></data>
+  <data name="Settings_Subtitle" xml:space="preserve"><value>Verwalte dein Profil und deine Fächer.</value></data>
+  <data name="Settings_Profile" xml:space="preserve"><value>Profil</value></data>
+  <data name="Settings_DisplayName" xml:space="preserve"><value>Anzeigename</value></data>
+  <data name="Settings_Saved" xml:space="preserve"><value>Gespeichert.</value></data>
+  <data name="Settings_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="Settings_MemberSince" xml:space="preserve"><value>Mitglied seit</value></data>
+  <data name="Settings_Subjects" xml:space="preserve"><value>Fächer</value></data>
+  <data name="Settings_SystemBadge" xml:space="preserve"><value>System</value></data>
+  <data name="Settings_NewSubjectPlaceholder" xml:space="preserve"><value>Name des neuen Fachs</value></data>
+  <data name="Settings_SubjectInUseError" xml:space="preserve"><value>Ein Fach mit zugeordneten Prüfungen kann nicht gelöscht werden. Lösche oder verschiebe diese Prüfungen zuerst.</value></data>
+  <data name="Settings_Data" xml:space="preserve"><value>Daten</value></data>
+  <data name="Settings_ExportTitle" xml:space="preserve"><value>Meine Daten exportieren</value></data>
+  <data name="Settings_ExportSub" xml:space="preserve"><value>Lade alle deine Prüfungen und Noten herunter, einschließlich vergangener benoteter.</value></data>
+  <data name="Settings_Feedback" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Settings_FeedbackTitle" xml:space="preserve"><value>Feedback &amp; Funktionswünsche</value></data>
+  <data name="Settings_FeedbackSub" xml:space="preserve"><value>Melde einen Fehler oder schlage eine Verbesserung vor.</value></data>
+  <data name="Settings_Account" xml:space="preserve"><value>Konto</value></data>
+  <data name="Settings_DeleteAccount" xml:space="preserve"><value>Konto löschen</value></data>
+  <data name="Settings_DeleteAccountSub" xml:space="preserve"><value>Entfernt dein Konto und alle Prüfungsdaten dauerhaft.</value></data>
+  <data name="Settings_AreYouSure" xml:space="preserve"><value>Bist du sicher?</value></data>
+  <data name="Settings_DeleteConfirmOne" xml:space="preserve"><value>Dadurch werden dein Konto, 1 Prüfung und alle eigenen Fächer dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.</value></data>
+  <data name="Settings_DeleteConfirmFmt" xml:space="preserve"><value>Dadurch werden dein Konto, alle {0} Prüfungen und alle eigenen Fächer dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.</value></data>
+  <data name="Settings_DeleteEverything" xml:space="preserve"><value>Ja, alles löschen</value></data>
+  <data name="Settings_Deleting" xml:space="preserve"><value>Wird gelöscht…</value></data>
+  <data name="Language" xml:space="preserve"><value>Sprache</value></data>
+
+  <!-- ===== Feedback page ===== -->
+  <data name="Feedback_Title" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Subtitle" xml:space="preserve"><value>Fehler gefunden oder eine Idee? Lass es mich wissen.</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Feedback einreichen</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Feedback_CategoryBug" xml:space="preserve"><value>Fehler</value></data>
+  <data name="Feedback_CategoryFeature" xml:space="preserve"><value>Funktionswunsch</value></data>
+  <data name="Feedback_CategoryOther" xml:space="preserve"><value>Sonstiges</value></data>
+  <data name="Feedback_Message" xml:space="preserve"><value>Nachricht</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Beschreibe den Fehler oder deine Idee…</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Feedback senden</value></data>
+  <data name="Feedback_Sending" xml:space="preserve"><value>Wird gesendet…</value></data>
+  <data name="Feedback_Thanks" xml:space="preserve"><value>Danke — dein Feedback wurde übermittelt.</value></data>
+  <data name="Feedback_AdminTitle" xml:space="preserve"><value>Alle Einsendungen (Admin)</value></data>
+  <data name="Feedback_Empty" xml:space="preserve"><value>Noch kein Feedback eingegangen.</value></data>
+  <data name="Feedback_EmptyError" xml:space="preserve"><value>Die Feedback-Nachricht darf nicht leer sein.</value></data>
+  <data name="Feedback_StatusOpen" xml:space="preserve"><value>Offen</value></data>
+  <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Geprüft</value></data>
+  <data name="Feedback_StatusClosed" xml:space="preserve"><value>Geschlossen</value></data>
+
+  <!-- ===== Error / not-found pages ===== -->
+  <data name="NotFound_Title" xml:space="preserve"><value>Seite nicht gefunden</value></data>
+  <data name="NotFound_Sub" xml:space="preserve"><value>Die gesuchte Seite existiert nicht oder wurde verschoben.</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Etwas ist schiefgelaufen</value></data>
+  <data name="Error_Sub" xml:space="preserve"><value>Ein unerwarteter Fehler ist aufgetreten. Falls das weiterhin passiert, melde dich ab und wieder an.</value></data>
+</root>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -198,6 +198,8 @@
   <data name="Feedback_Empty" xml:space="preserve"><value>Noch kein Feedback eingegangen.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Die Feedback-Nachricht darf nicht leer sein.</value></data>
   <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Dein Feedback konnte nicht übermittelt werden. Bitte überprüfe deine Nachricht und versuche es erneut.</value></data>
+  <data name="Feedback_YourSubmissions" xml:space="preserve"><value>Dein Feedback</value></data>
+  <data name="Feedback_YourEmpty" xml:space="preserve"><value>Du hast noch kein Feedback eingereicht.</value></data>
   <data name="Feedback_StatusLabel" xml:space="preserve"><value>Status</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Offen</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Geprüft</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -201,6 +201,105 @@
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Geprüft</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Geschlossen</value></data>
 
+  <!-- ===== Shared legal / demo ===== -->
+  <data name="Common_SignIn" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="Legal_Privacy" xml:space="preserve"><value>Datenschutz</value></data>
+  <data name="Legal_Terms" xml:space="preserve"><value>Nutzungsbedingungen</value></data>
+  <data name="Demo_Math" xml:space="preserve"><value>Mathe</value></data>
+  <data name="Demo_French" xml:space="preserve"><value>Französisch</value></data>
+  <data name="Demo_Chemistry" xml:space="preserve"><value>Chemie</value></data>
+  <data name="Demo_German" xml:space="preserve"><value>Deutsch</value></data>
+  <data name="Demo_English" xml:space="preserve"><value>Englisch</value></data>
+
+  <!-- ===== Landing page ===== -->
+  <data name="Landing_LogoTag" xml:space="preserve"><value>was soll ich heute lernen</value></data>
+  <data name="Landing_NavScore" xml:space="preserve"><value>Die Punktzahl</value></data>
+  <data name="Landing_NavTry" xml:space="preserve"><value>Ausprobieren</value></data>
+  <data name="Landing_NavHow" xml:space="preserve"><value>So funktioniert's</value></data>
+  <data name="Landing_HeroEyebrow" xml:space="preserve"><value>Kostenlos für Schüler · Entwickelt in Zürich</value></data>
+  <data name="Landing_HeroLine1" xml:space="preserve"><value>Was soll ich</value></data>
+  <data name="Landing_HeroLine2Pre" xml:space="preserve"><value>heute </value></data>
+  <data name="Landing_HeroLine2Em" xml:space="preserve"><value>lernen?</value></data>
+  <data name="Landing_HeroSub" xml:space="preserve"><value>Fünf Fächer, drei Prüfungen nächste Woche, ein freier Abend. WSIST bewertet jede anstehende Prüfung — Dringlichkeit, Umfang, wie gut du sie verstehst, wie deine Noten stehen — und sagt dir genau, was heute Abend dran ist.</value></data>
+  <data name="Landing_SeeScore" xml:space="preserve"><value>Punktzahl ansehen</value></data>
+  <data name="Landing_HeroNoteBold" xml:space="preserve"><value>Kostenlos</value></data>
+  <data name="Landing_HeroNoteRest" xml:space="preserve"><value>· keine Werbung · deine Prüfungen bleiben deine</value></data>
+  <data name="Landing_Card1Tag" xml:space="preserve"><value>Heutige Wahl</value></data>
+  <data name="Landing_Because" xml:space="preserve"><value>Weil:</value></data>
+  <data name="Landing_Card1Because" xml:space="preserve"><value>du verstehst es kaum, die Prüfung hat sehr viel Stoff, sie ist in 2 Tagen.</value></data>
+  <data name="Landing_Card2Because" xml:space="preserve"><value>mittleres Verständnis, viel Stoff, dein Schnitt in Französisch ist 4.1.</value></data>
+  <data name="Landing_Card3Because" xml:space="preserve"><value>durchschnittliches Verständnis, mittlerer Stoff, sie ist in 9 Tagen.</value></data>
+  <data name="Landing_HighestStudiesFirst" xml:space="preserve"><value>Die höchste Punktzahl wird zuerst gelernt</value></data>
+  <data name="Landing_RubricEyebrow" xml:space="preserve"><value>Die Engine</value></data>
+  <data name="Landing_RubricTitlePre" xml:space="preserve"><value>Deine Prüfungen, </value></data>
+  <data name="Landing_RubricTitleEm" xml:space="preserve"><value>bewertet.</value></data>
+  <data name="Landing_RubricSub" xml:space="preserve"><value>Die Schule benotet dich das ganze Jahr. WSIST dreht den Spieß um — jede anstehende Prüfung erhält eine Prioritätspunktzahl von 40, aus vier Faktoren. Kein Bauchgefühl, kein schlechtes Gewissen. Nur Mathematik.</value></data>
+  <data name="Landing_UrgencyDesc" xml:space="preserve"><value>Morgen schlägt nächsten Monat. Die verbleibenden Tage geben den Takt vor.</value></data>
+  <data name="Landing_PtsMax" xml:space="preserve"><value>Pkt. max</value></data>
+  <data name="Landing_VolumeDesc" xml:space="preserve"><value>Drei Kapitel wiegen mehr als ein Arbeitsblatt.</value></data>
+  <data name="Landing_VolumeDetail" xml:space="preserve"><value>sehr wenig +2 → sehr viel +12</value></data>
+  <data name="Landing_UnderstandingDesc" xml:space="preserve"><value>Je weniger es sitzt, desto weiter steigt sie.</value></data>
+  <data name="Landing_UnderstandingDetail" xml:space="preserve"><value>sehr hoch +2 → sehr niedrig +12</value></data>
+  <data name="Landing_GradePullName" xml:space="preserve"><value>Notendruck</value></data>
+  <data name="Landing_GradePullDesc" xml:space="preserve"><value>Fächer, in denen dein Schnitt abrutscht, bekommen einen Schub.</value></data>
+  <data name="Landing_PlayEyebrow" xml:space="preserve"><value>Demo ohne Anmeldung</value></data>
+  <data name="Landing_PlayTitlePre" xml:space="preserve"><value>Lass den </value></data>
+  <data name="Landing_PlayTitleEm" xml:space="preserve"><value>echten</value></data>
+  <data name="Landing_PlayTitlePost" xml:space="preserve"><value> Algorithmus laufen.</value></data>
+  <data name="Landing_PlaySub" xml:space="preserve"><value>Diese Regler speisen dieselben Bewertungsregeln, die produktiv auf wsist.forch.me laufen. Bewege sie und sieh zu, wie eine Prüfung in deiner Liste nach oben klettert.</value></data>
+  <data name="Landing_CtlDays" xml:space="preserve"><value>Tage bis zur Prüfung</value></data>
+  <data name="Landing_ScaleToday" xml:space="preserve"><value>heute</value></data>
+  <data name="Landing_Scale5Weeks" xml:space="preserve"><value>in 5 Wochen</value></data>
+  <data name="Landing_CtlVol" xml:space="preserve"><value>Prüfungsumfang</value></data>
+  <data name="Landing_ScaleWorksheet" xml:space="preserve"><value>ein Arbeitsblatt</value></data>
+  <data name="Landing_ScaleChapters" xml:space="preserve"><value>drei Kapitel</value></data>
+  <data name="Landing_CtlUnd" xml:space="preserve"><value>Dein Verständnis</value></data>
+  <data name="Landing_ScaleWhatEven" xml:space="preserve"><value>was ist das überhaupt</value></data>
+  <data name="Landing_ScaleCouldTeach" xml:space="preserve"><value>könnte es unterrichten</value></data>
+  <data name="Landing_CtlAvg" xml:space="preserve"><value>Dein Schnitt in diesem Fach</value></data>
+  <data name="Landing_Scale6Swiss" xml:space="preserve"><value>6.0 — Schweizer Skala</value></data>
+  <data name="Landing_ResultEyebrow" xml:space="preserve"><value>Prioritätspunktzahl</value></data>
+  <data name="Landing_ResultDenom" xml:space="preserve"><value>/ 40 Pkt.</value></data>
+  <data name="Landing_ChipUrgency" xml:space="preserve"><value>dringlichkeit</value></data>
+  <data name="Landing_ChipVolume" xml:space="preserve"><value>umfang</value></data>
+  <data name="Landing_ChipUnderstanding" xml:space="preserve"><value>verständnis</value></data>
+  <data name="Landing_ChipGradePull" xml:space="preserve"><value>notendruck</value></data>
+  <data name="Landing_ResultFoot" xml:space="preserve"><value>Dieselbe Rechnung wie in der echten App</value></data>
+  <data name="Landing_VerdictInitial" xml:space="preserve"><value>Lass alles stehen — das ist für heute Abend.</value></data>
+  <data name="Landing_HowEyebrow" xml:space="preserve"><value>Der Ablauf</value></data>
+  <data name="Landing_HowTitlePre" xml:space="preserve"><value>Zwanzig Sekunden rein, </value></data>
+  <data name="Landing_HowTitleEm" xml:space="preserve"><value>eine Antwort</value></data>
+  <data name="Landing_HowTitlePost" xml:space="preserve"><value> raus.</value></data>
+  <data name="Landing_Step1Title" xml:space="preserve"><value>Prüfung hinzufügen.</value></data>
+  <data name="Landing_Step1Desc" xml:space="preserve"><value>Titel, Fach, Datum, wie umfangreich sie ist, wie gut du sie verstehst. Zwanzig Sekunden, einmal pro Prüfung.</value></data>
+  <data name="Landing_MockTestTitle" xml:space="preserve"><value>Prüfungstitel</value></data>
+  <data name="Landing_MockSubjectDue" xml:space="preserve"><value>Fach  ·  Fälligkeitsdatum</value></data>
+  <data name="Landing_Step2Title" xml:space="preserve"><value>Sag, wie viel Zeit du hast.</value></data>
+  <data name="Landing_Step2Desc" xml:space="preserve"><value>Ein Eingabefeld. „Wie viele Stunden kannst du heute lernen?“ ist die einzige Frage, die WSIST dir je zurückstellt.</value></data>
+  <data name="Landing_MockHours" xml:space="preserve"><value>Wie viele Stunden kannst du heute lernen?</value></data>
+  <data name="Landing_Step3Title" xml:space="preserve"><value>Lerne, was oben auf der Liste steht.</value></data>
+  <data name="Landing_Step3Desc" xml:space="preserve"><value>Jede Prüfung von 40 bewertet, mit ausformulierten Gründen — damit du der Reihenfolge vertraust, statt sie zu hinterfragen.</value></data>
+  <data name="Landing_FeatEyebrow" xml:space="preserve"><value>Außerdem dabei</value></data>
+  <data name="Landing_FeatTitle" xml:space="preserve"><value>Die leisen Teile.</value></data>
+  <data name="Landing_Feat1Title" xml:space="preserve"><value>Notenübersicht pro Fach</value></data>
+  <data name="Landing_Feat1Desc" xml:space="preserve"><value>Deine Schnitte auf dem Dashboard, immer aktuell — so fällt ein abrutschendes Fach auf, bevor es das Zeugnis tut.</value></data>
+  <data name="Landing_Feat2Title" xml:space="preserve"><value>Deine Fächer, keine Vorgabe</value></data>
+  <data name="Landing_Feat2Desc" xml:space="preserve"><value>Füge die Fächer hinzu, die deine Schule tatsächlich unterrichtet. Wirtschaft, Werkstatt, was auch immer — WSIST ist das egal, es bewertet einfach.</value></data>
+  <data name="Landing_Feat3Title" xml:space="preserve"><value>Jeder Rang erklärt sich selbst</value></data>
+  <data name="Landing_Feat3Desc" xml:space="preserve"><value>Tippe auf eine Karte für die Aufschlüsselung der Punktzahl. Du siehst immer, warum eine Prüfung dort steht, wo sie steht.</value></data>
+  <data name="Landing_Feat4Title" xml:space="preserve"><value>Mit Google anmelden</value></data>
+  <data name="Landing_Feat4Desc" xml:space="preserve"><value>Nichts Neues zu merken. Dein Schulkonto funktioniert problemlos.</value></data>
+  <data name="Landing_Feat5Title" xml:space="preserve"><value>Privat von Haus aus</value></data>
+  <data name="Landing_Feat5Desc" xml:space="preserve"><value>Deine Prüfungen und Noten sind nur für dich sichtbar, und du kannst sie jederzeit löschen. Keine Werbung, niemals.</value></data>
+  <data name="Landing_Soon" xml:space="preserve"><value>Bald</value></data>
+  <data name="Landing_Feat6Desc" xml:space="preserve"><value>Ein tägliches Lern-Briefing auf Schweizerdeutsch, dazu eine Android-App. Entsteht zwischen den Prüfungswochen.</value></data>
+  <data name="Landing_ManifestoPre" xml:space="preserve"><value>Entstanden zwischen Lehrlingsschichten und Prüfungswochen — von einem Schüler, der </value></data>
+  <data name="Landing_ManifestoBold" xml:space="preserve"><value>wollte, dass es existiert.</value></data>
+  <data name="Landing_CtaTitlePre" xml:space="preserve"><value>Deine nächste Prüfung kommt </value></data>
+  <data name="Landing_CtaTitleEm" xml:space="preserve"><value>so oder so.</value></data>
+  <data name="Landing_CtaSmall" xml:space="preserve"><value>Kostenlos · läuft in jedem Browser</value></data>
+  <data name="Landing_FooterMade" xml:space="preserve"><value>Erstellt in Zürich · © 2026 Tim Hug</value></data>
+
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Seite nicht gefunden</value></data>
   <data name="NotFound_Sub" xml:space="preserve"><value>Die gesuchte Seite existiert nicht oder wurde verschoben.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -198,6 +198,7 @@
   <data name="Feedback_Empty" xml:space="preserve"><value>Noch kein Feedback eingegangen.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Die Feedback-Nachricht darf nicht leer sein.</value></data>
   <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Dein Feedback konnte nicht übermittelt werden. Bitte überprüfe deine Nachricht und versuche es erneut.</value></data>
+  <data name="Feedback_StatusLabel" xml:space="preserve"><value>Status</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Offen</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Geprüft</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Geschlossen</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -300,6 +300,97 @@
   <data name="Landing_CtaSmall" xml:space="preserve"><value>Free · works in any browser</value></data>
   <data name="Landing_FooterMade" xml:space="preserve"><value>Made in Zürich · © 2026 Tim Hug</value></data>
 
+  <!-- ===== Legal: shared ===== -->
+  <data name="Legal_LastUpdated" xml:space="preserve"><value>Last updated:</value></data>
+
+  <!-- ===== Privacy policy (section bodies rendered as MarkupString) ===== -->
+  <data name="Privacy_Title" xml:space="preserve"><value>Privacy Policy</value></data>
+  <data name="Privacy_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Who we are&lt;/h2&gt;
+&lt;p&gt;WSIST ("What Should I Study Today") is a personal study planning application developed and operated by Tim Hug, based in Switzerland. This privacy policy explains what personal data we collect, how we use it, and what rights you have.&lt;/p&gt;
+&lt;p&gt;Contact: &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Data we collect&lt;/h2&gt;
+&lt;p&gt;When you sign in with Google, we receive and store the following data from Google's OAuth service:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;strong&gt;Email address&lt;/strong&gt; — used to identify your account&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Display name&lt;/strong&gt; — shown in the application&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Google user ID&lt;/strong&gt; — used to link your Google account to your WSIST account&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;We also store data you create while using the application:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Test entries (title, subject, due date, volume, understanding level, grade)&lt;/li&gt;
+&lt;li&gt;Custom subjects you create&lt;/li&gt;
+&lt;li&gt;Your display name if you update it in settings&lt;/li&gt;
+&lt;li&gt;Your account creation timestamp&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;We do not collect location data, device identifiers, or any data beyond what is listed above.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. How we use your data&lt;/h2&gt;
+&lt;p&gt;Your data is used solely to provide the WSIST service:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Authenticating you when you log in&lt;/li&gt;
+&lt;li&gt;Storing and displaying your test entries&lt;/li&gt;
+&lt;li&gt;Calculating study recommendations and priority scores&lt;/li&gt;
+&lt;li&gt;Showing your grade overview&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;We do not sell your data, share it with advertisers, or use it for any purpose other than providing the service.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec4" xml:space="preserve"><value>&lt;h2&gt;4. Legal basis for processing (GDPR / Swiss nDSG)&lt;/h2&gt;
+&lt;p&gt;We process your personal data on the basis of &lt;strong&gt;contract performance&lt;/strong&gt; (Art. 6(1)(b) GDPR) — processing is necessary to provide the service you have requested. By creating an account and using WSIST, you enter into a contract with us for the provision of the application.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Third-party services&lt;/h2&gt;
+&lt;p&gt;&lt;strong&gt;Google OAuth:&lt;/strong&gt; Login is handled via Google's OAuth 2.0 service. When you authenticate, Google shares your profile data with us as described in section 2. Google's own privacy policy applies to the authentication process: &lt;a href="https://policies.google.com/privacy" target="_blank" rel="noopener"&gt;policies.google.com/privacy&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Railway:&lt;/strong&gt; The application is hosted on Railway (railway.app). Your data is stored on a MySQL database on their infrastructure. Railway's privacy policy applies to hosting: &lt;a href="https://railway.app/legal/privacy" target="_blank" rel="noopener"&gt;railway.app/legal/privacy&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; The application is served behind Cloudflare's CDN. Cloudflare may process connection metadata (IP address, request headers) as part of its service. Cloudflare's privacy policy: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Data retention&lt;/h2&gt;
+&lt;p&gt;Your data is retained for as long as you have an active account. If you wish to delete your account and all associated data, contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt; and we will delete it within 30 days.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Your rights&lt;/h2&gt;
+&lt;p&gt;Under the GDPR and Swiss nDSG, you have the following rights:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;strong&gt;Access:&lt;/strong&gt; You can request a copy of all personal data we hold about you.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Rectification:&lt;/strong&gt; You can correct inaccurate data via the Settings page or by contacting us.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Erasure:&lt;/strong&gt; You can request deletion of your account and all associated data.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Portability:&lt;/strong&gt; You can request your data in a machine-readable format.&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Objection:&lt;/strong&gt; You can object to processing in certain circumstances.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;To exercise any of these rights, contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;. We will respond within 30 days.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Cookies and sessions&lt;/h2&gt;
+&lt;p&gt;WSIST uses a single authentication cookie (.AspNetCore.Cookies) to maintain your login session. This cookie is strictly necessary for the application to function and does not track you across other websites. No analytics, advertising, or third-party tracking cookies are used.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Security&lt;/h2&gt;
+&lt;p&gt;Your data is transmitted over HTTPS. Passwords are never stored — authentication is handled entirely by Google. Database access is restricted to the application only.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Changes to this policy&lt;/h2&gt;
+&lt;p&gt;If we make material changes to this policy, we will update the "last updated" date at the top of this page. Continued use of WSIST after changes constitutes acceptance of the updated policy.&lt;/p&gt;</value></data>
+  <data name="Privacy_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Contact&lt;/h2&gt;
+&lt;p&gt;Questions about this privacy policy? Contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+
+  <!-- ===== Terms of use (section bodies rendered as MarkupString) ===== -->
+  <data name="Terms_Title" xml:space="preserve"><value>Terms of Use</value></data>
+  <data name="Terms_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Acceptance of terms&lt;/h2&gt;
+&lt;p&gt;By accessing or using WSIST ("What Should I Study Today") at wsist.forch.me, you agree to be bound by these Terms of Use. If you do not agree, do not use the service.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Description of service&lt;/h2&gt;
+&lt;p&gt;WSIST is a personal study planning tool that helps students track upcoming tests, estimate their preparedness, and determine what to study on a given day. The service is provided free of charge for personal, non-commercial use.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. Account and access&lt;/h2&gt;
+&lt;p&gt;Access to WSIST requires a Google account. By signing in, you authorise WSIST to receive your name and email address from Google as described in our &lt;a href="/privacy"&gt;Privacy Policy&lt;/a&gt;. You are responsible for keeping your Google account secure.&lt;/p&gt;
+&lt;p&gt;One account per person. You may not share your account with others or create accounts on behalf of third parties.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec4" xml:space="preserve"><value>&lt;h2&gt;4. Acceptable use&lt;/h2&gt;
+&lt;p&gt;You agree not to:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Use WSIST for any unlawful purpose&lt;/li&gt;
+&lt;li&gt;Attempt to access other users' data&lt;/li&gt;
+&lt;li&gt;Attempt to reverse-engineer, disrupt, or overload the service&lt;/li&gt;
+&lt;li&gt;Use automated tools to scrape or extract data from the service&lt;/li&gt;
+&lt;/ul&gt;</value></data>
+  <data name="Terms_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Your content&lt;/h2&gt;
+&lt;p&gt;You own the data you enter into WSIST (test entries, subjects, grades). We do not claim any ownership over it. You grant us a limited licence to store and process it solely for the purpose of providing the service to you.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Service availability&lt;/h2&gt;
+&lt;p&gt;WSIST is a personal project and is provided on an "as is" and "as available" basis. We make no guarantees about uptime, data preservation, or continued availability. We may modify or discontinue the service at any time without notice.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Disclaimer of warranties&lt;/h2&gt;
+&lt;p&gt;To the fullest extent permitted by law, WSIST is provided without warranties of any kind, express or implied. We do not warrant that the service will be error-free, uninterrupted, or that the study recommendations it produces will lead to any particular academic outcome.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Limitation of liability&lt;/h2&gt;
+&lt;p&gt;To the fullest extent permitted by applicable law, Tim Hug and the WSIST project shall not be liable for any indirect, incidental, or consequential damages arising from your use of or inability to use the service.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Changes to terms&lt;/h2&gt;
+&lt;p&gt;We may update these terms at any time. The "last updated" date at the top of this page will reflect any changes. Continued use of WSIST after changes are posted constitutes acceptance of the updated terms.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Governing law&lt;/h2&gt;
+&lt;p&gt;These terms are governed by the laws of Switzerland, without regard to conflict of law principles. Any disputes arising from these terms shall be subject to the exclusive jurisdiction of the courts of the Canton of Zurich, Switzerland.&lt;/p&gt;</value></data>
+  <data name="Terms_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Contact&lt;/h2&gt;
+&lt;p&gt;Questions about these terms? Contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Page not found</value></data>
   <data name="NotFound_Sub" xml:space="preserve"><value>The page you're looking for doesn't exist or has been moved.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -198,6 +198,8 @@
   <data name="Feedback_Empty" xml:space="preserve"><value>No feedback submitted yet.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Feedback message cannot be empty.</value></data>
   <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Your feedback couldn't be submitted. Please check your message and try again.</value></data>
+  <data name="Feedback_YourSubmissions" xml:space="preserve"><value>Your feedback</value></data>
+  <data name="Feedback_YourEmpty" xml:space="preserve"><value>You haven't submitted any feedback yet.</value></data>
   <data name="Feedback_StatusLabel" xml:space="preserve"><value>Status</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Open</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Reviewed</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -201,6 +201,105 @@
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Reviewed</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Closed</value></data>
 
+  <!-- ===== Shared legal / demo ===== -->
+  <data name="Common_SignIn" xml:space="preserve"><value>Sign in</value></data>
+  <data name="Legal_Privacy" xml:space="preserve"><value>Privacy</value></data>
+  <data name="Legal_Terms" xml:space="preserve"><value>Terms</value></data>
+  <data name="Demo_Math" xml:space="preserve"><value>Math</value></data>
+  <data name="Demo_French" xml:space="preserve"><value>French</value></data>
+  <data name="Demo_Chemistry" xml:space="preserve"><value>Chemistry</value></data>
+  <data name="Demo_German" xml:space="preserve"><value>German</value></data>
+  <data name="Demo_English" xml:space="preserve"><value>English</value></data>
+
+  <!-- ===== Landing page ===== -->
+  <data name="Landing_LogoTag" xml:space="preserve"><value>what should I study today</value></data>
+  <data name="Landing_NavScore" xml:space="preserve"><value>The score</value></data>
+  <data name="Landing_NavTry" xml:space="preserve"><value>Try it</value></data>
+  <data name="Landing_NavHow" xml:space="preserve"><value>How it works</value></data>
+  <data name="Landing_HeroEyebrow" xml:space="preserve"><value>Free for students · Built in Zürich</value></data>
+  <data name="Landing_HeroLine1" xml:space="preserve"><value>What should</value></data>
+  <data name="Landing_HeroLine2Pre" xml:space="preserve"><value>I study </value></data>
+  <data name="Landing_HeroLine2Em" xml:space="preserve"><value>today?</value></data>
+  <data name="Landing_HeroSub" xml:space="preserve"><value>Five subjects, three tests next week, one free evening. WSIST scores every upcoming test — urgency, volume, how well you get it, where your grades stand — and tells you exactly where tonight goes.</value></data>
+  <data name="Landing_SeeScore" xml:space="preserve"><value>See the score</value></data>
+  <data name="Landing_HeroNoteBold" xml:space="preserve"><value>Free</value></data>
+  <data name="Landing_HeroNoteRest" xml:space="preserve"><value>· no ads · your tests stay yours</value></data>
+  <data name="Landing_Card1Tag" xml:space="preserve"><value>Tonight's pick</value></data>
+  <data name="Landing_Because" xml:space="preserve"><value>Because:</value></data>
+  <data name="Landing_Card1Because" xml:space="preserve"><value>you have low understanding, the test has very high volume, it's in 2 days.</value></data>
+  <data name="Landing_Card2Because" xml:space="preserve"><value>medium understanding, high volume, your avg in French is 4.1.</value></data>
+  <data name="Landing_Card3Because" xml:space="preserve"><value>average understanding, medium volume, it's in 9 days.</value></data>
+  <data name="Landing_HighestStudiesFirst" xml:space="preserve"><value>The highest score studies first</value></data>
+  <data name="Landing_RubricEyebrow" xml:space="preserve"><value>The engine</value></data>
+  <data name="Landing_RubricTitlePre" xml:space="preserve"><value>Your tests, </value></data>
+  <data name="Landing_RubricTitleEm" xml:space="preserve"><value>graded.</value></data>
+  <data name="Landing_RubricSub" xml:space="preserve"><value>School grades you all year. WSIST turns the table — every upcoming test earns a priority score out of 40, built from four factors. No vibes, no guilt. Just arithmetic.</value></data>
+  <data name="Landing_UrgencyDesc" xml:space="preserve"><value>Tomorrow beats next month. Days left set the clock.</value></data>
+  <data name="Landing_PtsMax" xml:space="preserve"><value>pts max</value></data>
+  <data name="Landing_VolumeDesc" xml:space="preserve"><value>Three chapters outweigh one worksheet.</value></data>
+  <data name="Landing_VolumeDetail" xml:space="preserve"><value>very low +2 → very high +12</value></data>
+  <data name="Landing_UnderstandingDesc" xml:space="preserve"><value>The less it clicks, the higher it climbs.</value></data>
+  <data name="Landing_UnderstandingDetail" xml:space="preserve"><value>very high +2 → very low +12</value></data>
+  <data name="Landing_GradePullName" xml:space="preserve"><value>Grade pull</value></data>
+  <data name="Landing_GradePullDesc" xml:space="preserve"><value>Subjects where your average slips get a push.</value></data>
+  <data name="Landing_PlayEyebrow" xml:space="preserve"><value>No-signup demo</value></data>
+  <data name="Landing_PlayTitlePre" xml:space="preserve"><value>Run the </value></data>
+  <data name="Landing_PlayTitleEm" xml:space="preserve"><value>real</value></data>
+  <data name="Landing_PlayTitlePost" xml:space="preserve"><value> algorithm.</value></data>
+  <data name="Landing_PlaySub" xml:space="preserve"><value>These sliders feed the same scoring rules that run in production at wsist.forch.me. Move them and watch a test climb your list.</value></data>
+  <data name="Landing_CtlDays" xml:space="preserve"><value>Days until the test</value></data>
+  <data name="Landing_ScaleToday" xml:space="preserve"><value>today</value></data>
+  <data name="Landing_Scale5Weeks" xml:space="preserve"><value>5 weeks out</value></data>
+  <data name="Landing_CtlVol" xml:space="preserve"><value>Test volume</value></data>
+  <data name="Landing_ScaleWorksheet" xml:space="preserve"><value>one worksheet</value></data>
+  <data name="Landing_ScaleChapters" xml:space="preserve"><value>three chapters</value></data>
+  <data name="Landing_CtlUnd" xml:space="preserve"><value>Your understanding</value></data>
+  <data name="Landing_ScaleWhatEven" xml:space="preserve"><value>what even is this</value></data>
+  <data name="Landing_ScaleCouldTeach" xml:space="preserve"><value>could teach it</value></data>
+  <data name="Landing_CtlAvg" xml:space="preserve"><value>Your average in this subject</value></data>
+  <data name="Landing_Scale6Swiss" xml:space="preserve"><value>6.0 — Swiss scale</value></data>
+  <data name="Landing_ResultEyebrow" xml:space="preserve"><value>Priority score</value></data>
+  <data name="Landing_ResultDenom" xml:space="preserve"><value>/ 40 pts</value></data>
+  <data name="Landing_ChipUrgency" xml:space="preserve"><value>urgency</value></data>
+  <data name="Landing_ChipVolume" xml:space="preserve"><value>volume</value></data>
+  <data name="Landing_ChipUnderstanding" xml:space="preserve"><value>understanding</value></data>
+  <data name="Landing_ChipGradePull" xml:space="preserve"><value>grade pull</value></data>
+  <data name="Landing_ResultFoot" xml:space="preserve"><value>Same maths as the production engine</value></data>
+  <data name="Landing_VerdictInitial" xml:space="preserve"><value>Drop everything — this is tonight.</value></data>
+  <data name="Landing_HowEyebrow" xml:space="preserve"><value>The routine</value></data>
+  <data name="Landing_HowTitlePre" xml:space="preserve"><value>Twenty seconds in, </value></data>
+  <data name="Landing_HowTitleEm" xml:space="preserve"><value>one answer</value></data>
+  <data name="Landing_HowTitlePost" xml:space="preserve"><value> out.</value></data>
+  <data name="Landing_Step1Title" xml:space="preserve"><value>Add the test.</value></data>
+  <data name="Landing_Step1Desc" xml:space="preserve"><value>Title, subject, date, how big it is, how well you get it. Twenty seconds, once per test.</value></data>
+  <data name="Landing_MockTestTitle" xml:space="preserve"><value>Test title</value></data>
+  <data name="Landing_MockSubjectDue" xml:space="preserve"><value>Subject  ·  Due date</value></data>
+  <data name="Landing_Step2Title" xml:space="preserve"><value>Say how much time you have.</value></data>
+  <data name="Landing_Step2Desc" xml:space="preserve"><value>One input. “How many hours can you study today?” is the only question WSIST ever asks you back.</value></data>
+  <data name="Landing_MockHours" xml:space="preserve"><value>How many hours can you study today?</value></data>
+  <data name="Landing_Step3Title" xml:space="preserve"><value>Study the top of the list.</value></data>
+  <data name="Landing_Step3Desc" xml:space="preserve"><value>Every test ranked out of 40, with the reasons spelled out — so you trust the order instead of second-guessing it.</value></data>
+  <data name="Landing_FeatEyebrow" xml:space="preserve"><value>Also in the box</value></data>
+  <data name="Landing_FeatTitle" xml:space="preserve"><value>The quiet parts.</value></data>
+  <data name="Landing_Feat1Title" xml:space="preserve"><value>Grade overview per subject</value></data>
+  <data name="Landing_Feat1Desc" xml:space="preserve"><value>Your averages on the dashboard, always current — so a slipping subject shows up before the report card does.</value></data>
+  <data name="Landing_Feat2Title" xml:space="preserve"><value>Your subjects, not a preset</value></data>
+  <data name="Landing_Feat2Desc" xml:space="preserve"><value>Add the subjects your school actually teaches. Wirtschaft, Werkstatt, whatever — WSIST doesn't care, it just scores.</value></data>
+  <data name="Landing_Feat3Title" xml:space="preserve"><value>Every rank explains itself</value></data>
+  <data name="Landing_Feat3Desc" xml:space="preserve"><value>Tap any card for its score breakdown. You always see why a test sits where it sits.</value></data>
+  <data name="Landing_Feat4Title" xml:space="preserve"><value>Sign in with Google</value></data>
+  <data name="Landing_Feat4Desc" xml:space="preserve"><value>Nothing new to remember. Your school account works fine.</value></data>
+  <data name="Landing_Feat5Title" xml:space="preserve"><value>Private by default</value></data>
+  <data name="Landing_Feat5Desc" xml:space="preserve"><value>Your tests and grades are visible to you alone, and you can delete them anytime. No ads, ever.</value></data>
+  <data name="Landing_Soon" xml:space="preserve"><value>Soon</value></data>
+  <data name="Landing_Feat6Desc" xml:space="preserve"><value>A daily study briefing in Swiss German, plus an Android app. In the works between exam weeks.</value></data>
+  <data name="Landing_ManifestoPre" xml:space="preserve"><value>Built between apprenticeship shifts and exam weeks — by a student who </value></data>
+  <data name="Landing_ManifestoBold" xml:space="preserve"><value>needed it to exist.</value></data>
+  <data name="Landing_CtaTitlePre" xml:space="preserve"><value>Your next test is coming </value></data>
+  <data name="Landing_CtaTitleEm" xml:space="preserve"><value>either way.</value></data>
+  <data name="Landing_CtaSmall" xml:space="preserve"><value>Free · works in any browser</value></data>
+  <data name="Landing_FooterMade" xml:space="preserve"><value>Made in Zürich · © 2026 Tim Hug</value></data>
+
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Page not found</value></data>
   <data name="NotFound_Sub" xml:space="preserve"><value>The page you're looking for doesn't exist or has been moved.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -197,6 +197,7 @@
   <data name="Feedback_AdminTitle" xml:space="preserve"><value>All submissions (admin)</value></data>
   <data name="Feedback_Empty" xml:space="preserve"><value>No feedback submitted yet.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Feedback message cannot be empty.</value></data>
+  <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Your feedback couldn't be submitted. Please check your message and try again.</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Open</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Reviewed</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Closed</value></data>
@@ -291,7 +292,9 @@
   <data name="Landing_Feat4Desc" xml:space="preserve"><value>Nothing new to remember. Your school account works fine.</value></data>
   <data name="Landing_Feat5Title" xml:space="preserve"><value>Private by default</value></data>
   <data name="Landing_Feat5Desc" xml:space="preserve"><value>Your tests and grades are visible to you alone, and you can delete them anytime. No ads, ever.</value></data>
+  <data name="Landing_WsistSays" xml:space="preserve"><value>“WSIST says”</value></data>
   <data name="Landing_Soon" xml:space="preserve"><value>Soon</value></data>
+  <data name="Landing_ManifestoAttribution" xml:space="preserve"><value>Tim · Computer Science Apprentice · Zürich</value></data>
   <data name="Landing_Feat6Desc" xml:space="preserve"><value>A daily study briefing in Swiss German, plus an Android app. In the works between exam weeks.</value></data>
   <data name="Landing_ManifestoPre" xml:space="preserve"><value>Built between apprenticeship shifts and exam weeks — by a student who </value></data>
   <data name="Landing_ManifestoBold" xml:space="preserve"><value>needed it to exist.</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <!-- ===== Common / shared ===== -->
+  <data name="Common_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Common_Logout" xml:space="preserve"><value>Logout</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common_Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Common_Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Common_Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="Common_Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Remove</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>Open</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="Common_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Common_Study" xml:space="preserve"><value>Study</value></data>
+  <data name="Common_BackToHome" xml:space="preserve"><value>Back to home</value></data>
+  <data name="Common_ContinueWithGoogle" xml:space="preserve"><value>Continue with Google</value></data>
+  <data name="Common_Points" xml:space="preserve"><value>pts</value></data>
+  <data name="Common_InOneDay" xml:space="preserve"><value>in 1 day</value></data>
+  <data name="Common_InDaysFmt" xml:space="preserve"><value>in {0} days</value></data>
+
+  <!-- ===== Volume / understanding levels ===== -->
+  <data name="Level_VeryLow" xml:space="preserve"><value>Very Low</value></data>
+  <data name="Level_Low" xml:space="preserve"><value>Low</value></data>
+  <data name="Level_Medium" xml:space="preserve"><value>Medium</value></data>
+  <data name="Level_Average" xml:space="preserve"><value>Average</value></data>
+  <data name="Level_High" xml:space="preserve"><value>High</value></data>
+  <data name="Level_VeryHigh" xml:space="preserve"><value>Very High</value></data>
+
+  <!-- ===== Subject validation (shared by Home modal + Settings) ===== -->
+  <data name="Subject_EmptyError" xml:space="preserve"><value>Subject name cannot be empty.</value></data>
+  <data name="Subject_DuplicateError" xml:space="preserve"><value>A subject with that name already exists.</value></data>
+
+  <!-- ===== Home ===== -->
+  <data name="Home_Title" xml:space="preserve"><value>Your tests</value></data>
+  <data name="Home_Subtitle" xml:space="preserve"><value>Upcoming exams and assessments.</value></data>
+  <data name="Home_ShowPast" xml:space="preserve"><value>Show past</value></data>
+  <data name="Home_HidePast" xml:space="preserve"><value>Hide past</value></data>
+  <data name="Home_AddTest" xml:space="preserve"><value>Add test</value></data>
+  <data name="Home_EnterMissingGrades" xml:space="preserve"><value>Enter missing grades</value></data>
+  <data name="Home_StudyToday" xml:space="preserve"><value>Study today</value></data>
+  <data name="Home_FullPlan" xml:space="preserve"><value>Full plan</value></data>
+  <data name="Home_NoUpcomingTitle" xml:space="preserve"><value>No upcoming tests</value></data>
+  <data name="Home_NoUpcomingSub" xml:space="preserve"><value>Add your first test to get started.</value></data>
+  <data name="Home_ColTitle" xml:space="preserve"><value>Title</value></data>
+  <data name="Home_ColSubject" xml:space="preserve"><value>Subject</value></data>
+  <data name="Home_ColDate" xml:space="preserve"><value>Date</value></data>
+  <data name="Home_ColVolume" xml:space="preserve"><value>Volume</value></data>
+  <data name="Home_ColUnderstanding" xml:space="preserve"><value>Understanding</value></data>
+  <data name="Home_Grades" xml:space="preserve"><value>Grades</value></data>
+  <data name="Home_GradeTrends" xml:space="preserve"><value>Grade trends</value></data>
+  <data name="Home_TestCountOne" xml:space="preserve"><value>1 test</value></data>
+  <data name="Home_TestCountFmt" xml:space="preserve"><value>{0} tests</value></data>
+
+  <!-- ===== Test modal ===== -->
+  <data name="Modal_AddTest" xml:space="preserve"><value>Add test</value></data>
+  <data name="Modal_EditTest" xml:space="preserve"><value>Edit test</value></data>
+  <data name="Modal_Title" xml:space="preserve"><value>Title</value></data>
+  <data name="Modal_TitlePlaceholder" xml:space="preserve"><value>e.g. Maths Exam</value></data>
+  <data name="Modal_Subject" xml:space="preserve"><value>Subject</value></data>
+  <data name="Modal_AddNewSubject" xml:space="preserve"><value>+ Add new subject</value></data>
+  <data name="Modal_NewSubjectPlaceholder" xml:space="preserve"><value>New subject name</value></data>
+  <data name="Modal_DueDate" xml:space="preserve"><value>Due date</value></data>
+  <data name="Modal_Volume" xml:space="preserve"><value>Volume</value></data>
+  <data name="Modal_Understanding" xml:space="preserve"><value>Understanding</value></data>
+  <data name="Modal_Grade" xml:space="preserve"><value>Grade</value></data>
+  <data name="Modal_GradeAfterDate" xml:space="preserve"><value>(available after test date)</value></data>
+  <data name="Modal_SaveChanges" xml:space="preserve"><value>Save changes</value></data>
+
+  <!-- ===== Study ===== -->
+  <data name="Study_Title" xml:space="preserve"><value>What should I study?</value></data>
+  <data name="Study_Subtitle" xml:space="preserve"><value>Tell us how much time you have — we'll figure out the rest.</value></data>
+  <data name="Study_Today" xml:space="preserve"><value>Today</value></data>
+  <data name="Study_ThisWeek" xml:space="preserve"><value>This week</value></data>
+  <data name="Study_HoursToday" xml:space="preserve"><value>Hours available today</value></data>
+  <data name="Study_Calculate" xml:space="preserve"><value>Calculate</value></data>
+  <data name="Study_CaughtUpTitle" xml:space="preserve"><value>You're all caught up</value></data>
+  <data name="Study_CaughtUpSub" xml:space="preserve"><value>No upcoming tests — enjoy your free time.</value></data>
+  <data name="Study_StudyTheseToday" xml:space="preserve"><value>Study these today</value></data>
+  <data name="Study_HowUnderstanding" xml:space="preserve"><value>How's your understanding now?</value></data>
+  <data name="Study_StudiedIt" xml:space="preserve"><value>Studied it</value></data>
+  <data name="Study_HoursEachDay" xml:space="preserve"><value>Hours available each day</value></data>
+  <data name="Study_PlanMyWeek" xml:space="preserve"><value>Plan my week</value></data>
+  <data name="Study_DayOff" xml:space="preserve"><value>Day off</value></data>
+  <data name="Study_OneDayAway" xml:space="preserve"><value>1 day away</value></data>
+  <data name="Study_DaysAwayFmt" xml:space="preserve"><value>{0} days away</value></data>
+  <data name="Score_Urgency" xml:space="preserve"><value>Urgency</value></data>
+  <data name="Score_Volume" xml:space="preserve"><value>Volume</value></data>
+  <data name="Score_Understanding" xml:space="preserve"><value>Understanding</value></data>
+  <data name="Score_Grade" xml:space="preserve"><value>Grade</value></data>
+  <data name="Because_Understanding" xml:space="preserve"><value>you have {0} understanding</value></data>
+  <data name="Because_Volume" xml:space="preserve"><value>the test has {0} volume</value></data>
+  <data name="Because_InOneDay" xml:space="preserve"><value>it's in 1 day</value></data>
+  <data name="Because_InDaysFmt" xml:space="preserve"><value>it's in {0} days</value></data>
+  <data name="Because_AvgGradeFmt" xml:space="preserve"><value>your average grade in {0} is {1}</value></data>
+
+  <!-- ===== Settings ===== -->
+  <data name="Settings_Title" xml:space="preserve"><value>Settings</value></data>
+  <data name="Settings_Subtitle" xml:space="preserve"><value>Manage your profile and subjects.</value></data>
+  <data name="Settings_Profile" xml:space="preserve"><value>Profile</value></data>
+  <data name="Settings_DisplayName" xml:space="preserve"><value>Display name</value></data>
+  <data name="Settings_Saved" xml:space="preserve"><value>Saved.</value></data>
+  <data name="Settings_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="Settings_MemberSince" xml:space="preserve"><value>Member since</value></data>
+  <data name="Settings_Subjects" xml:space="preserve"><value>Subjects</value></data>
+  <data name="Settings_SystemBadge" xml:space="preserve"><value>system</value></data>
+  <data name="Settings_NewSubjectPlaceholder" xml:space="preserve"><value>New subject name</value></data>
+  <data name="Settings_SubjectInUseError" xml:space="preserve"><value>Cannot delete a subject that still has tests. Delete or reassign those tests first.</value></data>
+  <data name="Settings_Data" xml:space="preserve"><value>Data</value></data>
+  <data name="Settings_ExportTitle" xml:space="preserve"><value>Export my data</value></data>
+  <data name="Settings_ExportSub" xml:space="preserve"><value>Download all your tests and grades, including past graded ones.</value></data>
+  <data name="Settings_Feedback" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Settings_FeedbackTitle" xml:space="preserve"><value>Feedback &amp; feature requests</value></data>
+  <data name="Settings_FeedbackSub" xml:space="preserve"><value>Report a bug or suggest an improvement.</value></data>
+  <data name="Settings_Account" xml:space="preserve"><value>Account</value></data>
+  <data name="Settings_DeleteAccount" xml:space="preserve"><value>Delete account</value></data>
+  <data name="Settings_DeleteAccountSub" xml:space="preserve"><value>Permanently removes your account and all test data.</value></data>
+  <data name="Settings_AreYouSure" xml:space="preserve"><value>Are you sure?</value></data>
+  <data name="Settings_DeleteConfirmOne" xml:space="preserve"><value>This will permanently delete your account, 1 test, and all custom subjects. This cannot be undone.</value></data>
+  <data name="Settings_DeleteConfirmFmt" xml:space="preserve"><value>This will permanently delete your account, all {0} tests, and all custom subjects. This cannot be undone.</value></data>
+  <data name="Settings_DeleteEverything" xml:space="preserve"><value>Yes, delete everything</value></data>
+  <data name="Settings_Deleting" xml:space="preserve"><value>Deleting…</value></data>
+  <data name="Language" xml:space="preserve"><value>Language</value></data>
+
+  <!-- ===== Feedback page ===== -->
+  <data name="Feedback_Title" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Subtitle" xml:space="preserve"><value>Found a bug or have an idea? Let me know.</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Submit feedback</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Category</value></data>
+  <data name="Feedback_CategoryBug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Feedback_CategoryFeature" xml:space="preserve"><value>Feature request</value></data>
+  <data name="Feedback_CategoryOther" xml:space="preserve"><value>Other</value></data>
+  <data name="Feedback_Message" xml:space="preserve"><value>Message</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Describe the bug or your idea…</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Send feedback</value></data>
+  <data name="Feedback_Sending" xml:space="preserve"><value>Sending…</value></data>
+  <data name="Feedback_Thanks" xml:space="preserve"><value>Thanks — your feedback was submitted.</value></data>
+  <data name="Feedback_AdminTitle" xml:space="preserve"><value>All submissions (admin)</value></data>
+  <data name="Feedback_Empty" xml:space="preserve"><value>No feedback submitted yet.</value></data>
+  <data name="Feedback_EmptyError" xml:space="preserve"><value>Feedback message cannot be empty.</value></data>
+  <data name="Feedback_StatusOpen" xml:space="preserve"><value>Open</value></data>
+  <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Reviewed</value></data>
+  <data name="Feedback_StatusClosed" xml:space="preserve"><value>Closed</value></data>
+
+  <!-- ===== Error / not-found pages ===== -->
+  <data name="NotFound_Title" xml:space="preserve"><value>Page not found</value></data>
+  <data name="NotFound_Sub" xml:space="preserve"><value>The page you're looking for doesn't exist or has been moved.</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Something went wrong</value></data>
+  <data name="Error_Sub" xml:space="preserve"><value>An unexpected error occurred. If this keeps happening, try logging out and back in.</value></data>
+</root>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -198,6 +198,7 @@
   <data name="Feedback_Empty" xml:space="preserve"><value>No feedback submitted yet.</value></data>
   <data name="Feedback_EmptyError" xml:space="preserve"><value>Feedback message cannot be empty.</value></data>
   <data name="Feedback_SubmitValidationError" xml:space="preserve"><value>Your feedback couldn't be submitted. Please check your message and try again.</value></data>
+  <data name="Feedback_StatusLabel" xml:space="preserve"><value>Status</value></data>
   <data name="Feedback_StatusOpen" xml:space="preserve"><value>Open</value></data>
   <data name="Feedback_StatusReviewed" xml:space="preserve"><value>Reviewed</value></data>
   <data name="Feedback_StatusClosed" xml:space="preserve"><value>Closed</value></data>

--- a/WSIST/WSIST.Web/SharedResource.cs
+++ b/WSIST/WSIST.Web/SharedResource.cs
@@ -1,0 +1,9 @@
+namespace WSIST.Web;
+
+// Marker type for the single shared localization resource. All UI strings live
+// in Resources/SharedResource.resx (English) and Resources/SharedResource.de.resx
+// (German). Pages inject IStringLocalizer<SharedResource> and look strings up by
+// key. A single shared resource (rather than one resx per component) keeps the
+// German terminology consistent across pages and makes it easy to scan one file
+// for any missing/untranslated key.
+public sealed class SharedResource { }

--- a/WSIST/WSIST.Web/appsettings.json
+++ b/WSIST/WSIST.Web/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "Admin": {
-    "Comment": "Email of the account allowed to view the feedback listing. Override in production via the Admin__Email environment variable.",
-    "Email": "tim.an.zurich@gmail.com"
+    "Comment": "Email of the account allowed to view the feedback listing. Set per environment via the Admin__Email environment variable (or appsettings.Development.json locally). Blank means nobody is admin.",
+    "Email": ""
   }
 }

--- a/WSIST/WSIST.Web/appsettings.json
+++ b/WSIST/WSIST.Web/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Admin": {
+    "Comment": "Email of the account allowed to view the feedback listing. Override in production via the Admin__Email environment variable.",
+    "Email": "tim.an.zurich@gmail.com"
+  }
 }

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -124,6 +124,8 @@ main {
     align-items: center;
     gap: 9px;
     margin-right: auto;
+    text-decoration: none;
+    color: inherit;
 }
 
 .nav-brand span {
@@ -1133,6 +1135,17 @@ h1:focus {
     align-items: center;
     flex-wrap: wrap;
     gap: 10px;
+}
+
+.feedback-status-select {
+    margin-left: auto;
+    padding: 3px 8px;
+    font-size: 12px;
+    background: var(--bg-subtle);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xs);
+    cursor: pointer;
 }
 
 .feedback-meta {

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1046,6 +1046,86 @@ h1:focus {
     border-top: 1px solid var(--border);
 }
 
+/* ── Feedback ── */
+
+.feedback-form {
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.feedback-label {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-top: 4px;
+}
+
+.feedback-textarea {
+    resize: vertical;
+    min-height: 120px;
+    font-family: inherit;
+    line-height: 1.45;
+}
+
+.feedback-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+
+.feedback-empty {
+    padding: 16px 18px;
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+.feedback-item {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.feedback-item:last-child {
+    border-bottom: none;
+}
+
+.feedback-item-head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.feedback-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.feedback-email {
+    color: var(--text-muted);
+}
+
+.feedback-item-message {
+    font-size: 14px;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+}
+
+.feedback-cat-bug {
+    color: #f87171;
+    border-color: #f87171;
+}
+
+.feedback-cat-feature {
+    color: #4ade80;
+    border-color: #4ade80;
+}
+
 /* ── Error Page ── */
 
 .error-page {

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1148,7 +1148,7 @@ h1:focus {
     font-size: 14px;
     color: var(--text-primary);
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
     margin: 0;
 }
 

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1137,6 +1137,19 @@ h1:focus {
     gap: 10px;
 }
 
+.feedback-status-tag {
+    margin-left: auto;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xs);
+    padding: 2px 7px;
+}
+
 .feedback-status-select {
     margin-left: auto;
     padding: 3px 8px;

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1076,6 +1076,12 @@ h1:focus {
     color: var(--text-muted);
 }
 
+.landing-nav-actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
 /* ── Feedback ── */
 
 .feedback-form {

--- a/WSIST/WSIST.Web/wwwroot/app.css
+++ b/WSIST/WSIST.Web/wwwroot/app.css
@@ -1046,6 +1046,36 @@ h1:focus {
     border-top: 1px solid var(--border);
 }
 
+/* ── Language toggle ── */
+
+.lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    user-select: none;
+}
+
+.lang-toggle .lang-option {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 2px 4px;
+    border-radius: var(--radius-xs);
+}
+
+.lang-toggle .lang-option:hover {
+    color: var(--text-primary);
+}
+
+.lang-toggle .lang-option.active {
+    color: var(--accent);
+}
+
+.lang-toggle .lang-sep {
+    color: var(--text-muted);
+}
+
 /* ── Feedback ── */
 
 .feedback-form {

--- a/WSIST/WSIST.Web/wwwroot/landing.js
+++ b/WSIST/WSIST.Web/wwwroot/landing.js
@@ -61,7 +61,41 @@
 
   var VOLUME_PTS        = [2, 4, 6, 8, 10, 12];
   var UNDERSTANDING_PTS = [12, 10, 8, 6, 4, 2];
-  var LEVEL_LABELS = ["Very low", "Low", "Medium", "Average", "High", "Very high"];
+
+  /* The playground runs entirely client-side, so its dynamic labels can't use
+     the server's IStringLocalizer. Mirror the two shipped languages here and
+     pick by <html lang>, which Program.cs sets from the current UI culture. */
+  var STRINGS = {
+    en: {
+      levels: ["Very low", "Low", "Medium", "Average", "High", "Very high"],
+      today: "today",
+      tomorrow: "tomorrow",
+      inDays: function (d) { return "in " + d + " days"; },
+      verdicts: [
+        "Drop everything — this is tonight.",
+        "High on the list. Start here.",
+        "On the radar — schedule it this week.",
+        "Breathe. You've got time.",
+      ],
+    },
+    de: {
+      levels: ["Sehr niedrig", "Niedrig", "Mittel", "Durchschnittlich", "Hoch", "Sehr hoch"],
+      today: "heute",
+      tomorrow: "morgen",
+      inDays: function (d) { return "in " + d + " Tagen"; },
+      verdicts: [
+        "Lass alles stehen — das ist für heute Abend.",
+        "Weit oben auf der Liste. Fang hier an.",
+        "Auf dem Schirm — plane sie diese Woche ein.",
+        "Durchatmen. Du hast Zeit.",
+      ],
+    },
+  };
+  var T =
+    (document.documentElement.lang || "en").slice(0, 2).toLowerCase() === "de"
+      ? STRINGS.de
+      : STRINGS.en;
+  var LEVEL_LABELS = T.levels;
 
   function urgencyScore(days){
     if (days <= 1)  return 10;
@@ -110,16 +144,16 @@
   }
 
   function dayLabel(d){
-    if (d === 0) return "today";
-    if (d === 1) return "tomorrow";
-    return "in " + d + " days";
+    if (d === 0) return T.today;
+    if (d === 1) return T.tomorrow;
+    return T.inDays(d);
   }
 
   function verdictFor(total){
-    if (total >= 30) return "Drop everything — this is tonight.";
-    if (total >= 22) return "High on the list. Start here.";
-    if (total >= 12) return "On the radar — schedule it this week.";
-    return "Breathe. You've got time.";
+    if (total >= 30) return T.verdicts[0];
+    if (total >= 22) return T.verdicts[1];
+    if (total >= 12) return T.verdicts[2];
+    return T.verdicts[3];
   }
 
   var lastVerdict = "";


### PR DESCRIPTION
Consolidated branch for the remaining WSIST Polish & Feature Batch items (Tasks 4, 5, 3), kept on one branch for review rather than stacked PRs.

> **Note on base:** this branch is cut from the migration hotfix (#31) so it boots locally (main currently has the broken migration). The first commit here (`af8eab2`) is that hotfix — once #31 merges to main, it dedupes out of this diff. **Please review/merge #31 first.**

## Task 4 — Self-service data export (nDSG / GDPR portability)
- `GET /api/export?format=csv|json`, `RequireAuthorization`, resolves the user from their own auth claims and scopes the query strictly to that user id — one user's export can never contain another's.
- CSV: RFC-4180 escaping + formula-injection mitigation (leading `= + - @` etc. prefixed) + UTF-8 BOM for Excel/accented chars. JSON as a second format.
- Export links in Settings. Tests cover cross-user isolation, inclusion of past graded tests, CSV header/escaping/injection.

## Task 5 — In-app feedback / feature requests
- `Feedback` entity (UserId FK cascade, Message ≤4000, Category/Status enums as ints, CreatedAt indexed) + migration.
- `FeedbackManagement` service (validates/trims, caps length, newest-first admin projection). Authorization stays in the web layer.
- `/feedback` page: any signed-in user submits (category + message); admin-only listing gated by `Admin:Email` config (override via `Admin__Email` env var; blank = nobody is admin). `AuthenticatedComponentBase` now exposes `CurrentUserEmail`.
- Component named `FeedbackPage` to avoid colliding with the `Feedback` entity in Razor. 5 new tests.

## Task 3 — EN/DE language switch
- ASP.NET Core request localization with a single shared `IStringLocalizer<SharedResource>` resource (EN + DE satellite). One supported **culture** (en, so grade/date formatting never changes) but two supported **UI cultures** (en/de) — only the UI culture flips.
- `User.PreferredLanguage` column + migration. `DbRequestCultureProvider` resolves a signed-in user's stored language ahead of the cookie/Accept-Language providers, so the choice persists across logout/login; null falls through to the browser language (first-login default).
- `/set-language/{culture}` writes the culture cookie, persists the preference, and does an open-redirect-safe `LocalRedirect`. `EN / DE` toggle in every nav; `<html lang>` bound to the current UI culture.
- Every page translated: Home, Study, Settings, Feedback, the marketing landing page + its client-side playground (`landing.js` carries its own EN/DE table keyed off `<html lang>`), Privacy, Terms, and the error/not-found pages. German is High German (ß spelling, not Swiss); legal sections rendered via `MarkupString` from static, developer-authored resource HTML.

## Verification
- `dotnet build -c Release` clean; `dotnet test` 32/32 green; `dotnet csharpier` clean.
- Confirmed the EN resource compiles to `WSIST.Web.Resources.SharedResource.resources` and the `de/` satellite assembly is emitted.

## Reviewer notes
- The pre-existing `Title = "Some Test"` modal default is left as-is (changing to empty risks an empty-submit crash — out of scope here).
- Illustrative landing sample content (e.g. example test titles) is intentionally left literal; all real UI prose/labels are localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user feedback system with a dedicated `/feedback` page; users can submit categorized messages, and admins can review and update feedback statuses.
  * Added test export via `/api/export` supporting CSV and JSON.
  * Added multi-language support (English/German) with a language toggle and persisted preferred language selection.
  * Localized the user interface across core pages, including feedback, settings, and privacy/terms.
* **Bug Fixes**
  * Improved feedback listing to use deterministic newest-first ordering.
* **Tests**
  * Added unit tests covering feedback submission/status updates and CSV export formatting + formula-injection mitigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->