### PR TITLE
feat(k8s): Kubernetes manifests + auto-deploy CI/CD to k3s

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,21 +18,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set image tag
         id: tag
         run: echo "sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -37,18 +43,30 @@ jobs:
             ghcr.io/timh8127/wsist:latest
 
       - name: Connect to Tailnet
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@4e4c49acaa9818630ce0bd7a564372c17e33fb4d # v2
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
           version: latest
 
+      - name: Copy manifests to host
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
+        with:
+          host: ${{ secrets.K3S_HOST }}
+          username: ${{ secrets.K3S_USER }}
+          key: ${{ secrets.K3S_SSH_KEY }}
+          source: "k8s/*.yaml"
+          target: "/tmp/wsist-deploy"
+          strip_components: 1
+          rm: true
+
       - name: Deploy
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.K3S_HOST }}
           username: ${{ secrets.K3S_USER }}
           key: ${{ secrets.K3S_SSH_KEY }}
           script: |
+            kubectl apply -f /tmp/wsist-deploy/ -n wsist
             kubectl set image deployment/wsist-app \
               wsist-app=ghcr.io/timh8127/wsist:${{ steps.tag.outputs.sha }} \
               -n wsist

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,55 @@
+name: Deploy to k3s
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: tag
+        run: echo "sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/timh8127/wsist:${{ steps.tag.outputs.sha }}
+            ghcr.io/timh8127/wsist:latest
+
+      - name: Connect to Tailnet
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          version: latest
+
+      - name: Deploy
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.K3S_HOST }}
+          username: ${{ secrets.K3S_USER }}
+          key: ${{ secrets.K3S_SSH_KEY }}
+          script: |
+            kubectl set image deployment/wsist-app \
+              wsist-app=ghcr.io/timh8127/wsist:${{ steps.tag.outputs.sha }} \
+              -n wsist
+            kubectl rollout status deployment/wsist-app -n wsist --timeout=120s

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ WORKDIR /app
 COPY --from=build /app/publish .
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
+USER app
 ENTRYPOINT ["dotnet", "WSIST.Web.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish WSIST/WSIST.Web/WSIST.Web.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "WSIST.Web.dll"]

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wsist-app
+  namespace: wsist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wsist-app
+  template:
+    metadata:
+      labels:
+        app: wsist-app
+    spec:
+      containers:
+        - name: wsist-app
+          image: ghcr.io/timh8127/wsist:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production
+            - name: ASPNETCORE_URLS
+              value: http://+:8080
+            - name: Google__ClientId
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-app-secret
+                  key: Google__ClientId
+            - name: Google__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-app-secret
+                  key: Google__ClientSecret
+            - name: Admin__Email
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-app-secret
+                  key: Admin__Email
+            - name: ConnectionStrings__DatabaseConnection
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-app-secret
+                  key: ConnectionStrings__DatabaseConnection
+          readinessProbe:
+            httpGet:
+              path: /login-page
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /login-page
+              port: 8080
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wsist-app
+  namespace: wsist
+spec:
+  selector:
+    app: wsist-app
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -13,10 +13,30 @@ spec:
       labels:
         app: wsist-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: wsist-app
           image: ghcr.io/timh8127/wsist:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 8080
           env:
@@ -44,6 +64,9 @@ spec:
                 secretKeyRef:
                   name: wsist-app-secret
                   key: ConnectionStrings__DatabaseConnection
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /login-page
@@ -60,6 +83,9 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/cloudflared.yaml
+++ b/k8s/cloudflared.yaml
@@ -62,8 +62,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - NET_RAW
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/k8s/cloudflared.yaml
+++ b/k8s/cloudflared.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wsist-cloudflared
+  namespace: wsist
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wsist-cloudflared
+  template:
+    metadata:
+      labels:
+        app: wsist-cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-secret
+                  key: TUNNEL_TOKEN

--- a/k8s/cloudflared.yaml
+++ b/k8s/cloudflared.yaml
@@ -13,18 +13,60 @@ spec:
       labels:
         app: wsist-cloudflared
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:latest
+          image: cloudflare/cloudflared:2025.2.1
           args:
             - tunnel
             - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:2000
             - run
-            - --token
-            - $(TUNNEL_TOKEN)
           env:
             - name: TUNNEL_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: cloudflared-secret
                   key: TUNNEL_TOKEN
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_RAW
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/mysql.yaml
+++ b/k8s/mysql.yaml
@@ -76,6 +76,18 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/k8s/mysql.yaml
+++ b/k8s/mysql.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wsist-mysql
+  namespace: wsist
+spec:
+  selector:
+    app: wsist-mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wsist-mysql
+  namespace: wsist
+spec:
+  serviceName: wsist-mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wsist-mysql
+  template:
+    metadata:
+      labels:
+        app: wsist-mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-db-secret
+                  key: MYSQL_DATABASE
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-db-secret
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-db-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wsist-db-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
## Summary

Implements the WSIST Kubernetes manifests + CI/CD task.

### Task 1 — Kubernetes manifests (`k8s/`)
- **`k8s/mysql.yaml`** — headless `Service` + `StatefulSet` (mysql:8.0) in the `wsist` namespace; DB credentials sourced from the pre-existing `wsist-db-secret`; Longhorn-backed 5Gi PVC; `mysqladmin ping` liveness/readiness probes.
- **`k8s/app.yaml`** — `wsist-app` `Deployment` (image `ghcr.io/timh8127/wsist:latest`, `imagePullPolicy: Always`) + `Service` on 8080; app/Google/admin/connection-string config sourced from `wsist-app-secret`; `/login-page` HTTP probes.
- **`k8s/cloudflared.yaml`** — 2-replica `cloudflared` `Deployment` using the tunnel token from `cloudflared-secret`.

All `YOUR_GITHUB_USERNAME` placeholders replaced with `timh8127`. Manifests only *reference* the cluster secrets — they never define values.

### Task 2 — Deploy workflow (`.github/workflows/deploy.yaml`)
On push to `main`: build & push the image to `ghcr.io/timh8127/wsist` (sha + `latest` tags), connect to the Tailnet, then `kubectl set image` + `rollout status` over SSH. The existing `ci.yml` is untouched.

> **Action required (Tim):** the four secrets `TAILSCALE_AUTHKEY`, `K3S_HOST`, `K3S_USER`, `K3S_SSH_KEY` must be added in repo settings. `GITHUB_TOKEN` is provided automatically.

### Task 3 — Dockerfile
Verified the existing root `Dockerfile` already uses the correct project path `WSIST/WSIST.Web/WSIST.Web.csproj` — no change to its contents.

> **Note:** the `Dockerfile` was present in the working tree but **untracked**. The deploy workflow builds from it (`context: .`), so it would fail on first run without it. I committed it in its own commit (`build: track repo-root Dockerfile…`) so the two task-specified commits stay byte-for-byte as specified. The Dockerfile *contents* were not modified.

## Verification
- `dotnet test` → **35 passed, 0 failed**
- `dotnet csharpier check .` → 24 files, all formatted (no C# files changed by this PR)

*(Sandbox note: the installed SDK is 10.0.109 vs. the pinned 10.0.201, so the build needed `-p:AllowMissingPrunePackageData=true`; nothing in the repo was changed to accommodate this.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow to build and deploy the app to the k3s cluster on pushes to `main`, including image publishing and rollout completion waiting.
  * Introduced hardened Kubernetes deployments and service wiring for the application, including readiness/liveness probes and secret-based configuration.
  * Added a Cloudflared tunnel deployment and a headless MySQL StatefulSet with persistent storage.
* **Chores**
  * Updated the Docker build to a multi-stage approach for leaner production images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->