### PR TITLE
fix: update all domain references from wsist.forch.me to wsist.ch/app.wsist.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 WSIST is a Blazor Server study planner that helps students decide what to focus on each day. Enter your upcoming tests, rate your understanding and the workload, and WSIST ranks them by priority — so you always know what matters most right now.
 
-Live at **[wsist.forch.me](https://wsist.forch.me)**
+Live at **[app.wsist.ch](https://app.wsist.ch)**
 
 ---
 
@@ -121,7 +121,7 @@ dotnet test WSIST/WSIST.UnitTests
 
 ## Legal
 
-Privacy policy and Terms of Use are available at [wsist.forch.me/privacy](https://wsist.forch.me/privacy) and [wsist.forch.me/terms](https://wsist.forch.me/terms).
+Privacy policy and Terms of Use are available at [app.wsist.ch/privacy](https://app.wsist.ch/privacy) and [app.wsist.ch/terms](https://app.wsist.ch/terms).
 
 ---
 

--- a/WSIST/WSIST.Web/Components/Pages/Login.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Login.razor
@@ -350,7 +350,7 @@
         <div class="container foot">
             <span class="wm">WSIST<i>.</i> — @Localizer["Landing_LogoTag"]</span>
             <div class="foot-links">
-                <a href="https://wsist.forch.me">wsist.forch.me</a>
+                <a href="https://app.wsist.ch">app.wsist.ch</a>
                 <a href="/privacy">@Localizer["Legal_Privacy"]</a>
                 <a href="/terms">@Localizer["Legal_Terms"]</a>
             </div>

--- a/WSIST/WSIST.Web/Resources/SharedResource.de.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.de.resx
@@ -250,7 +250,7 @@
   <data name="Landing_PlayTitlePre" xml:space="preserve"><value>Lass den </value></data>
   <data name="Landing_PlayTitleEm" xml:space="preserve"><value>echten</value></data>
   <data name="Landing_PlayTitlePost" xml:space="preserve"><value> Algorithmus laufen.</value></data>
-  <data name="Landing_PlaySub" xml:space="preserve"><value>Diese Regler speisen dieselben Bewertungsregeln, die produktiv auf wsist.forch.me laufen. Bewege sie und sieh zu, wie eine Prüfung in deiner Liste nach oben klettert.</value></data>
+  <data name="Landing_PlaySub" xml:space="preserve"><value>Diese Regler speisen dieselben Bewertungsregeln, die produktiv auf app.wsist.ch laufen. Bewege sie und sieh zu, wie eine Prüfung in deiner Liste nach oben klettert.</value></data>
   <data name="Landing_CtlDays" xml:space="preserve"><value>Tage bis zur Prüfung</value></data>
   <data name="Landing_ScaleToday" xml:space="preserve"><value>heute</value></data>
   <data name="Landing_Scale5Weeks" xml:space="preserve"><value>in 5 Wochen</value></data>
@@ -313,7 +313,7 @@
   <data name="Privacy_Title" xml:space="preserve"><value>Datenschutzerklärung</value></data>
   <data name="Privacy_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Wer wir sind&lt;/h2&gt;
 &lt;p&gt;WSIST („What Should I Study Today“) ist eine persönliche Lernplanungs-Anwendung, entwickelt und betrieben von Tim Hug mit Sitz in der Schweiz. Diese Datenschutzerklärung erläutert, welche personenbezogenen Daten wir erheben, wie wir sie verwenden und welche Rechte du hast.&lt;/p&gt;
-&lt;p&gt;Kontakt: &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;&lt;/p&gt;</value></data>
+&lt;p&gt;Kontakt: &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;&lt;/p&gt;</value></data>
   <data name="Privacy_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Daten, die wir erheben&lt;/h2&gt;
 &lt;p&gt;Wenn du dich mit Google anmeldest, erhalten und speichern wir die folgenden Daten aus Googles OAuth-Dienst:&lt;/p&gt;
 &lt;ul&gt;
@@ -342,10 +342,9 @@
 &lt;p&gt;Wir verarbeiten deine personenbezogenen Daten auf Grundlage der &lt;strong&gt;Vertragserfüllung&lt;/strong&gt; (Art. 6 Abs. 1 lit. b DSGVO) — die Verarbeitung ist erforderlich, um den von dir angeforderten Dienst bereitzustellen. Mit der Erstellung eines Kontos und der Nutzung von WSIST schließt du mit uns einen Vertrag über die Bereitstellung der Anwendung.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Dienste von Drittanbietern&lt;/h2&gt;
 &lt;p&gt;&lt;strong&gt;Google OAuth:&lt;/strong&gt; Die Anmeldung erfolgt über Googles OAuth-2.0-Dienst. Bei der Authentifizierung teilt Google deine Profildaten mit uns, wie in Abschnitt 2 beschrieben. Für den Authentifizierungsvorgang gilt Googles eigene Datenschutzerklärung: &lt;a href="https://policies.google.com/privacy" target="_blank" rel="noopener"&gt;policies.google.com/privacy&lt;/a&gt;.&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;Railway:&lt;/strong&gt; Die Anwendung wird bei Railway (railway.app) gehostet. Deine Daten werden in einer MySQL-Datenbank auf deren Infrastruktur gespeichert. Für das Hosting gilt die Datenschutzerklärung von Railway: &lt;a href="https://railway.app/legal/privacy" target="_blank" rel="noopener"&gt;railway.app/legal/privacy&lt;/a&gt;.&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; Die Anwendung wird über das CDN von Cloudflare ausgeliefert. Cloudflare verarbeitet im Rahmen seines Dienstes möglicherweise Verbindungsmetadaten (IP-Adresse, Anfrage-Header). Datenschutzerklärung von Cloudflare: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; Die Anwendung wird über das CDN und den Tunnel von Cloudflare ausgeliefert. Cloudflare verarbeitet im Rahmen seines Dienstes möglicherweise Verbindungsmetadaten (IP-Adresse, Anfrage-Header). Datenschutzerklärung von Cloudflare: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Speicherdauer&lt;/h2&gt;
-&lt;p&gt;Deine Daten werden so lange gespeichert, wie du ein aktives Konto hast. Wenn du dein Konto und alle zugehörigen Daten löschen möchtest, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;, und wir löschen sie innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
+&lt;p&gt;Deine Daten werden so lange gespeichert, wie du ein aktives Konto hast. Wenn du dein Konto und alle zugehörigen Daten löschen möchtest, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;, und wir löschen sie innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Deine Rechte&lt;/h2&gt;
 &lt;p&gt;Nach DSGVO und Schweizer nDSG hast du die folgenden Rechte:&lt;/p&gt;
 &lt;ul&gt;
@@ -355,7 +354,7 @@
 &lt;li&gt;&lt;strong&gt;Datenübertragbarkeit:&lt;/strong&gt; Du kannst deine Daten in einem maschinenlesbaren Format anfordern.&lt;/li&gt;
 &lt;li&gt;&lt;strong&gt;Widerspruch:&lt;/strong&gt; Du kannst der Verarbeitung unter bestimmten Umständen widersprechen.&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p&gt;Um eines dieser Rechte auszuüben, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;. Wir antworten innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
+&lt;p&gt;Um eines dieser Rechte auszuüben, kontaktiere uns unter &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;. Wir antworten innerhalb von 30 Tagen.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Cookies und Sitzungen&lt;/h2&gt;
 &lt;p&gt;WSIST verwendet ein einziges Authentifizierungs-Cookie (.AspNetCore.Cookies), um deine Anmeldesitzung aufrechtzuerhalten. Dieses Cookie ist für die Funktion der Anwendung zwingend erforderlich und verfolgt dich nicht über andere Websites hinweg. Es werden keine Analyse-, Werbe- oder Tracking-Cookies von Dritten verwendet.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Sicherheit&lt;/h2&gt;
@@ -363,12 +362,12 @@
   <data name="Privacy_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Änderungen dieser Erklärung&lt;/h2&gt;
 &lt;p&gt;Wenn wir wesentliche Änderungen an dieser Erklärung vornehmen, aktualisieren wir das Datum „Zuletzt aktualisiert“ oben auf dieser Seite. Die fortgesetzte Nutzung von WSIST nach Änderungen gilt als Annahme der aktualisierten Erklärung.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Kontakt&lt;/h2&gt;
-&lt;p&gt;Fragen zu dieser Datenschutzerklärung? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;Fragen zu dieser Datenschutzerklärung? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;.&lt;/p&gt;</value></data>
 
   <!-- ===== Terms of use (section bodies rendered as MarkupString) ===== -->
   <data name="Terms_Title" xml:space="preserve"><value>Nutzungsbedingungen</value></data>
   <data name="Terms_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Annahme der Bedingungen&lt;/h2&gt;
-&lt;p&gt;Durch den Zugriff auf oder die Nutzung von WSIST („What Should I Study Today“) unter wsist.forch.me erklärst du dich mit diesen Nutzungsbedingungen einverstanden. Wenn du nicht einverstanden bist, nutze den Dienst nicht.&lt;/p&gt;</value></data>
+&lt;p&gt;Durch den Zugriff auf oder die Nutzung von WSIST („What Should I Study Today”) unter app.wsist.ch erklärst du dich mit diesen Nutzungsbedingungen einverstanden. Wenn du nicht einverstanden bist, nutze den Dienst nicht.&lt;/p&gt;</value></data>
   <data name="Terms_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Beschreibung des Dienstes&lt;/h2&gt;
 &lt;p&gt;WSIST ist ein persönliches Lernplanungs-Werkzeug, das Schülern hilft, anstehende Prüfungen zu verfolgen, ihren Vorbereitungsstand einzuschätzen und zu bestimmen, was an einem bestimmten Tag zu lernen ist. Der Dienst wird kostenlos für den persönlichen, nicht-kommerziellen Gebrauch bereitgestellt.&lt;/p&gt;</value></data>
   <data name="Terms_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. Konto und Zugang&lt;/h2&gt;
@@ -395,7 +394,7 @@
   <data name="Terms_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Anwendbares Recht&lt;/h2&gt;
 &lt;p&gt;Diese Bedingungen unterliegen dem Recht der Schweiz, unter Ausschluss der Kollisionsnormen. Für alle Streitigkeiten aus diesen Bedingungen sind ausschließlich die Gerichte des Kantons Zürich, Schweiz, zuständig.&lt;/p&gt;</value></data>
   <data name="Terms_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Kontakt&lt;/h2&gt;
-&lt;p&gt;Fragen zu diesen Bedingungen? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;Fragen zu diesen Bedingungen? Kontaktiere uns unter &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;.&lt;/p&gt;</value></data>
 
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Seite nicht gefunden</value></data>

--- a/WSIST/WSIST.Web/Resources/SharedResource.resx
+++ b/WSIST/WSIST.Web/Resources/SharedResource.resx
@@ -250,7 +250,7 @@
   <data name="Landing_PlayTitlePre" xml:space="preserve"><value>Run the </value></data>
   <data name="Landing_PlayTitleEm" xml:space="preserve"><value>real</value></data>
   <data name="Landing_PlayTitlePost" xml:space="preserve"><value> algorithm.</value></data>
-  <data name="Landing_PlaySub" xml:space="preserve"><value>These sliders feed the same scoring rules that run in production at wsist.forch.me. Move them and watch a test climb your list.</value></data>
+  <data name="Landing_PlaySub" xml:space="preserve"><value>These sliders feed the same scoring rules that run in production at app.wsist.ch. Move them and watch a test climb your list.</value></data>
   <data name="Landing_CtlDays" xml:space="preserve"><value>Days until the test</value></data>
   <data name="Landing_ScaleToday" xml:space="preserve"><value>today</value></data>
   <data name="Landing_Scale5Weeks" xml:space="preserve"><value>5 weeks out</value></data>
@@ -313,7 +313,7 @@
   <data name="Privacy_Title" xml:space="preserve"><value>Privacy Policy</value></data>
   <data name="Privacy_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Who we are&lt;/h2&gt;
 &lt;p&gt;WSIST ("What Should I Study Today") is a personal study planning application developed and operated by Tim Hug, based in Switzerland. This privacy policy explains what personal data we collect, how we use it, and what rights you have.&lt;/p&gt;
-&lt;p&gt;Contact: &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;&lt;/p&gt;</value></data>
+&lt;p&gt;Contact: &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;&lt;/p&gt;</value></data>
   <data name="Privacy_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Data we collect&lt;/h2&gt;
 &lt;p&gt;When you sign in with Google, we receive and store the following data from Google's OAuth service:&lt;/p&gt;
 &lt;ul&gt;
@@ -342,10 +342,9 @@
 &lt;p&gt;We process your personal data on the basis of &lt;strong&gt;contract performance&lt;/strong&gt; (Art. 6(1)(b) GDPR) — processing is necessary to provide the service you have requested. By creating an account and using WSIST, you enter into a contract with us for the provision of the application.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec5" xml:space="preserve"><value>&lt;h2&gt;5. Third-party services&lt;/h2&gt;
 &lt;p&gt;&lt;strong&gt;Google OAuth:&lt;/strong&gt; Login is handled via Google's OAuth 2.0 service. When you authenticate, Google shares your profile data with us as described in section 2. Google's own privacy policy applies to the authentication process: &lt;a href="https://policies.google.com/privacy" target="_blank" rel="noopener"&gt;policies.google.com/privacy&lt;/a&gt;.&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;Railway:&lt;/strong&gt; The application is hosted on Railway (railway.app). Your data is stored on a MySQL database on their infrastructure. Railway's privacy policy applies to hosting: &lt;a href="https://railway.app/legal/privacy" target="_blank" rel="noopener"&gt;railway.app/legal/privacy&lt;/a&gt;.&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; The application is served behind Cloudflare's CDN. Cloudflare may process connection metadata (IP address, request headers) as part of its service. Cloudflare's privacy policy: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;&lt;strong&gt;Cloudflare:&lt;/strong&gt; The application is served behind Cloudflare's CDN and Tunnel. Cloudflare may process connection metadata (IP address, request headers) as part of its service. Cloudflare's privacy policy: &lt;a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"&gt;cloudflare.com/privacypolicy&lt;/a&gt;.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec6" xml:space="preserve"><value>&lt;h2&gt;6. Data retention&lt;/h2&gt;
-&lt;p&gt;Your data is retained for as long as you have an active account. If you wish to delete your account and all associated data, contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt; and we will delete it within 30 days.&lt;/p&gt;</value></data>
+&lt;p&gt;Your data is retained for as long as you have an active account. If you wish to delete your account and all associated data, contact us at &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt; and we will delete it within 30 days.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec7" xml:space="preserve"><value>&lt;h2&gt;7. Your rights&lt;/h2&gt;
 &lt;p&gt;Under the GDPR and Swiss nDSG, you have the following rights:&lt;/p&gt;
 &lt;ul&gt;
@@ -355,7 +354,7 @@
 &lt;li&gt;&lt;strong&gt;Portability:&lt;/strong&gt; You can request your data in a machine-readable format.&lt;/li&gt;
 &lt;li&gt;&lt;strong&gt;Objection:&lt;/strong&gt; You can object to processing in certain circumstances.&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p&gt;To exercise any of these rights, contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;. We will respond within 30 days.&lt;/p&gt;</value></data>
+&lt;p&gt;To exercise any of these rights, contact us at &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;. We will respond within 30 days.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec8" xml:space="preserve"><value>&lt;h2&gt;8. Cookies and sessions&lt;/h2&gt;
 &lt;p&gt;WSIST uses a single authentication cookie (.AspNetCore.Cookies) to maintain your login session. This cookie is strictly necessary for the application to function and does not track you across other websites. No analytics, advertising, or third-party tracking cookies are used.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec9" xml:space="preserve"><value>&lt;h2&gt;9. Security&lt;/h2&gt;
@@ -363,12 +362,12 @@
   <data name="Privacy_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Changes to this policy&lt;/h2&gt;
 &lt;p&gt;If we make material changes to this policy, we will update the "last updated" date at the top of this page. Continued use of WSIST after changes constitutes acceptance of the updated policy.&lt;/p&gt;</value></data>
   <data name="Privacy_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Contact&lt;/h2&gt;
-&lt;p&gt;Questions about this privacy policy? Contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;Questions about this privacy policy? Contact us at &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;.&lt;/p&gt;</value></data>
 
   <!-- ===== Terms of use (section bodies rendered as MarkupString) ===== -->
   <data name="Terms_Title" xml:space="preserve"><value>Terms of Use</value></data>
   <data name="Terms_Sec1" xml:space="preserve"><value>&lt;h2&gt;1. Acceptance of terms&lt;/h2&gt;
-&lt;p&gt;By accessing or using WSIST ("What Should I Study Today") at wsist.forch.me, you agree to be bound by these Terms of Use. If you do not agree, do not use the service.&lt;/p&gt;</value></data>
+&lt;p&gt;By accessing or using WSIST ("What Should I Study Today") at app.wsist.ch, you agree to be bound by these Terms of Use. If you do not agree, do not use the service.&lt;/p&gt;</value></data>
   <data name="Terms_Sec2" xml:space="preserve"><value>&lt;h2&gt;2. Description of service&lt;/h2&gt;
 &lt;p&gt;WSIST is a personal study planning tool that helps students track upcoming tests, estimate their preparedness, and determine what to study on a given day. The service is provided free of charge for personal, non-commercial use.&lt;/p&gt;</value></data>
   <data name="Terms_Sec3" xml:space="preserve"><value>&lt;h2&gt;3. Account and access&lt;/h2&gt;
@@ -395,7 +394,7 @@
   <data name="Terms_Sec10" xml:space="preserve"><value>&lt;h2&gt;10. Governing law&lt;/h2&gt;
 &lt;p&gt;These terms are governed by the laws of Switzerland, without regard to conflict of law principles. Any disputes arising from these terms shall be subject to the exclusive jurisdiction of the courts of the Canton of Zurich, Switzerland.&lt;/p&gt;</value></data>
   <data name="Terms_Sec11" xml:space="preserve"><value>&lt;h2&gt;11. Contact&lt;/h2&gt;
-&lt;p&gt;Questions about these terms? Contact us at &lt;a href="mailto:privacy@wsist.forch.me"&gt;privacy@wsist.forch.me&lt;/a&gt;.&lt;/p&gt;</value></data>
+&lt;p&gt;Questions about these terms? Contact us at &lt;a href="mailto:privacy@wsist.ch"&gt;privacy@wsist.ch&lt;/a&gt;.&lt;/p&gt;</value></data>
 
   <!-- ===== Error / not-found pages ===== -->
   <data name="NotFound_Title" xml:space="preserve"><value>Page not found</value></data>


### PR DESCRIPTION
## Summary

- Replaced all `wsist.forch.me` URL references with `app.wsist.ch` across README, resx resource files, and Login.razor footer
- Updated all `privacy@wsist.forch.me` email references to `privacy@wsist.ch` in both English and German resource files
- Removed the Railway hosting paragraph from `Privacy_Sec5` in both `SharedResource.resx` and `SharedResource.de.resx`; replaced with Cloudflare CDN+Tunnel paragraph only (app no longer runs on Railway)

## Test plan

- [x] `dotnet test` — 35 tests, all passing
- [x] `dotnet csharpier format .` — 24 files formatted, no issues
- [x] Grep for `wsist.forch.me` and `privacy@wsist.forch.me` in changed files — zero remaining occurrences
- [ ] Verify Privacy page renders correctly (English + German) in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3Hm1WA4eBE8Du6LYDoL3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README and footer links to the new app domain.
  * Refreshed privacy, terms, and legal text in English and German to use the current website and contact addresses.
  * Improved the privacy policy wording for third-party services and data handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->