### PR TITLE
feat: add host-based routing — wsist.ch serves landing, app.wsist.ch serves app

### DIFF
--- a/WSIST/WSIST.Web/Components/Pages/Login.razor
+++ b/WSIST/WSIST.Web/Components/Pages/Login.razor
@@ -18,7 +18,7 @@
                 <a href="/login-page#try" data-enhance-nav="false">@Localizer["Landing_NavTry"]</a>
                 <a href="/login-page#how" data-enhance-nav="false">@Localizer["Landing_NavHow"]</a>
                 <LanguageToggle />
-                <a class="btn btn-primary btn-sm" href="/login" data-enhance-nav="false">@Localizer["Common_SignIn"]</a>
+                <a class="btn btn-primary btn-sm" href="https://app.wsist.ch/login" data-enhance-nav="false">@Localizer["Common_SignIn"]</a>
             </div>
         </div>
     </nav>
@@ -36,7 +36,7 @@
                     @Localizer["Landing_HeroSub"]
                 </p>
                 <div class="hero-ctas r-up js-reveal" style="--d:.38s">
-                    <a class="btn btn-primary" href="/login" data-enhance-nav="false">
+                    <a class="btn btn-primary" href="https://app.wsist.ch/login" data-enhance-nav="false">
                         <svg class="g-mark" viewBox="0 0 48 48" aria-hidden="true"><path fill="#FFC107" d="M43.6 20.1H42V20H24v8h11.3C33.7 32.7 29.2 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 13 4 4 13 4 24s9 20 20 20 20-9 20-20c0-1.3-.1-2.6-.4-3.9z"/><path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 15.1 19 12 24 12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 16.3 4 9.7 8.3 6.3 14.7z"/><path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.3C29.2 35.1 26.7 36 24 36c-5.2 0-9.6-3.3-11.3-8l-6.5 5C9.5 39.6 16.2 44 24 44z"/><path fill="#1976D2" d="M43.6 20.1H42V20H24v8h11.3c-.8 2.2-2.2 4.2-4.1 5.5l6.2 5.3C37 39.2 44 34 44 24c0-1.3-.1-2.6-.4-3.9z"/></svg>
                         @Localizer["Common_ContinueWithGoogle"]
                     </a>
@@ -336,7 +336,7 @@
         <div class="container">
             <h2 class="r-up js-reveal">@Localizer["Landing_CtaTitlePre"]<em>@Localizer["Landing_CtaTitleEm"]</em></h2>
             <div class="cta-row r-up js-reveal" style="--d:.1s">
-                <a class="btn btn-primary" href="/login" data-enhance-nav="false">
+                <a class="btn btn-primary" href="https://app.wsist.ch/login" data-enhance-nav="false">
                     <svg class="g-mark" viewBox="0 0 48 48" aria-hidden="true"><path fill="#FFC107" d="M43.6 20.1H42V20H24v8h11.3C33.7 32.7 29.2 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 13 4 4 13 4 24s9 20 20 20 20-9 20-20c0-1.3-.1-2.6-.4-3.9z"/><path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 15.1 19 12 24 12c3.1 0 5.9 1.2 8 3l5.7-5.7C34.3 6.1 29.4 4 24 4 16.3 4 9.7 8.3 6.3 14.7z"/><path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.3C29.2 35.1 26.7 36 24 36c-5.2 0-9.6-3.3-11.3-8l-6.5 5C9.5 39.6 16.2 44 24 44z"/><path fill="#1976D2" d="M43.6 20.1H42V20H24v8h11.3c-.8 2.2-2.2 4.2-4.1 5.5l6.2 5.3C37 39.2 44 34 44 24c0-1.3-.1-2.6-.4-3.9z"/></svg>
                     @Localizer["Common_ContinueWithGoogle"]
                 </a>

--- a/WSIST/WSIST.Web/Program.cs
+++ b/WSIST/WSIST.Web/Program.cs
@@ -92,16 +92,76 @@ app.UseAntiforgery();
 app.Use(
     async (context, next) =>
     {
+        var host = context.Request.Host.Host;
+        var path = context.Request.Path.Value ?? "/";
         var isAuthenticated = context.User?.Identity?.IsAuthenticated ?? false;
-        var protectedPaths = new[] { "/", "/study", "/settings", "/feedback" };
+
+        // wsist.ch — marketing/landing site
+        if (host == "wsist.ch" || host == "www.wsist.ch")
+        {
+            // Rewrite root to /login-page internally so the landing page renders
+            // at wsist.ch/ without showing /login-page in the browser URL bar.
+            if (path == "/")
+            {
+                context.Request.Path = "/login-page";
+                await next();
+                return;
+            }
+            // Allow OAuth flow, legal pages, and the login-page route through.
+            // Redirect anything else (e.g. /study, /settings) to the landing.
+            var allowedOnMarketing = new[]
+            {
+                "/login",
+                "/login-page",
+                "/privacy",
+                "/terms",
+                "/signin-google",
+            };
+            if (
+                !allowedOnMarketing.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase))
+            )
+            {
+                context.Response.Redirect("https://wsist.ch/", permanent: false);
+                return;
+            }
+            await next();
+            return;
+        }
+
+        // app.wsist.ch — the authenticated app
+        if (host == "app.wsist.ch")
+        {
+            var protectedPaths = new[] { "/", "/study", "/settings", "/feedback" };
+            if (protectedPaths.Contains(path, StringComparer.OrdinalIgnoreCase) && !isAuthenticated)
+            {
+                // Send unauthenticated users to the landing site
+                context.Response.Redirect("https://wsist.ch/");
+                return;
+            }
+            await next();
+            return;
+        }
+
+        // wsist.forch.me — permanent redirect to the app
+        if (host == "wsist.forch.me")
+        {
+            context.Response.Redirect(
+                $"https://app.wsist.ch{path}{context.Request.QueryString}",
+                permanent: true
+            );
+            return;
+        }
+
+        // Local development — existing behaviour
+        var localProtectedPaths = new[] { "/", "/study", "/settings", "/feedback" };
         if (
-            protectedPaths.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase)
-            && !isAuthenticated
+            localProtectedPaths.Contains(path, StringComparer.OrdinalIgnoreCase) && !isAuthenticated
         )
         {
             context.Response.Redirect("/login-page");
             return;
         }
+
         await next();
     }
 );


### PR DESCRIPTION
## Summary

- Replaced the single-purpose auth redirect middleware in `Program.cs` with a host-based routing middleware that handles three domains:
  - `wsist.ch` / `www.wsist.ch` — marketing/landing site; rewrites `/` internally to `/login-page`, blocks app routes, allows OAuth + legal paths through
  - `app.wsist.ch` — authenticated app; sends unauthenticated visitors to `https://wsist.ch/`
  - `wsist.forch.me` — permanent 301 redirect to `https://app.wsist.ch{path}{query}`
  - `localhost` / local dev — existing behaviour preserved unchanged
- Updated all three "Continue with Google" button links in `Login.razor` from `href="/login"` to `href="https://app.wsist.ch/login"` so the OAuth flow always originates from the app subdomain

## Manual step required after merge + deploy

Add to Google Cloud Console → Authorised redirect URIs:
- `https://wsist.ch/signin-google`

This covers the case where OAuth is initiated from `wsist.ch`.

## Test plan

- [x] `dotnet test` — 35 tests, all passing
- [x] `dotnet csharpier format .` — no issues
- [ ] Visit `wsist.ch/` — should render landing page (URL stays `wsist.ch/`)
- [ ] Visit `wsist.ch/study` — should redirect to `https://wsist.ch/`
- [ ] Visit `app.wsist.ch/` unauthenticated — should redirect to `https://wsist.ch/`
- [ ] Visit `app.wsist.ch/` authenticated — should show the app
- [ ] Visit `wsist.forch.me/anything` — should 301 to `https://app.wsist.ch/anything`
- [ ] Click "Continue with Google" on landing — should go to `https://app.wsist.ch/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)